### PR TITLE
feat: add --version and --help for pg_dump/pg_restore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,16 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 
+[[bin]]
+name = "pg_dump"
+path = "src/bin/pg_dump.rs"
+
+[[bin]]
+name = "pg_restore"
+path = "src/bin/pg_restore.rs"
+
+[[bin]]
+name = "pg_plumbing"
+path = "src/main.rs"
+
 [dev-dependencies]

--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! pg_dump — dump a PostgreSQL database.
+
+use clap::Parser;
+
+/// pg_dump dumps a database as a text file or to other formats.
+///
+/// Compatible with PostgreSQL's pg_dump.
+#[derive(Parser)]
+#[command(
+    name = "pg_dump",
+    version = pg_dump_version(),
+    about = "pg_dump dumps a database as a text file or to other formats."
+)]
+struct Cli {
+    /// Database name to dump
+    dbname: Option<String>,
+}
+
+/// Build the version string: `pg_dump (pg_plumbing) <version>`.
+fn pg_dump_version() -> &'static str {
+    concat!("pg_dump (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
+}
+
+fn main() -> anyhow::Result<()> {
+    let _cli = Cli::parse();
+
+    // Dump logic not yet implemented.
+    eprintln!("pg_dump: not yet implemented");
+    std::process::exit(1);
+}

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! pg_restore — restore a PostgreSQL database from an archive.
+
+use clap::Parser;
+
+/// pg_restore restores a PostgreSQL database from an archive
+/// created by pg_dump.
+///
+/// Compatible with PostgreSQL's pg_restore.
+#[derive(Parser)]
+#[command(
+    name = "pg_restore",
+    version = pg_restore_version(),
+    about = "pg_restore restores a PostgreSQL database from an archive created by pg_dump."
+)]
+struct Cli {
+    /// Archive file to restore
+    filename: Option<String>,
+}
+
+/// Build the version string: `pg_restore (pg_plumbing) <version>`.
+fn pg_restore_version() -> &'static str {
+    concat!("pg_restore (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
+}
+
+fn main() -> anyhow::Result<()> {
+    let _cli = Cli::parse();
+
+    // Restore logic not yet implemented.
+    eprintln!("pg_restore: not yet implemented");
+    std::process::exit(1);
+}

--- a/tests/pg_dump/t001_basic.rs
+++ b/tests/pg_dump/t001_basic.rs
@@ -12,16 +12,37 @@
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // RED — not yet implemented
 /// pg_dump --help exits 0 and prints usage info.
 /// Source: program_help_ok('pg_dump')
-fn pg_dump_help() {}
+fn pg_dump_help() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("--help")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(output.status.success(), "pg_dump --help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_dump"),
+        "help output should mention pg_dump"
+    );
+    assert!(stdout.contains("Usage"), "help output should contain Usage");
+}
 
 #[test]
-#[ignore]
 /// pg_dump --version exits 0 and prints version string.
 /// Source: program_version_ok('pg_dump')
-fn pg_dump_version() {}
+fn pg_dump_version() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("--version")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(output.status.success(), "pg_dump --version should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_dump (pg_plumbing)"),
+        "version output should contain 'pg_dump (pg_plumbing)'"
+    );
+}
 
 #[test]
 #[ignore]
@@ -30,16 +51,40 @@ fn pg_dump_version() {}
 fn pg_dump_options_handling() {}
 
 #[test]
-#[ignore]
 /// pg_restore --help exits 0 and prints usage info.
 /// Source: program_help_ok('pg_restore')
-fn pg_restore_help() {}
+fn pg_restore_help() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .arg("--help")
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(output.status.success(), "pg_restore --help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_restore"),
+        "help output should mention pg_restore"
+    );
+    assert!(stdout.contains("Usage"), "help output should contain Usage");
+}
 
 #[test]
-#[ignore]
 /// pg_restore --version exits 0 and prints version string.
 /// Source: program_version_ok('pg_restore')
-fn pg_restore_version() {}
+fn pg_restore_version() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .arg("--version")
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        output.status.success(),
+        "pg_restore --version should exit 0"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_restore (pg_plumbing)"),
+        "version output should contain 'pg_restore (pg_plumbing)'"
+    );
+}
 
 #[test]
 #[ignore]


### PR DESCRIPTION
## Summary
- Add separate `pg_dump` and `pg_restore` binary targets with clap CLI
- Implement `--version` (format: `<tool> (pg_plumbing) <version>`) and `--help` for both
- Un-ignore and implement 4 tests in `t001_basic.rs`: `pg_dump_version`, `pg_dump_help`, `pg_restore_version`, `pg_restore_help`

Closes #3

## Test plan
- [x] `cargo test --test pg_dump_tests -- t001_basic` — 4 passed, 59 ignored
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt -- --check` — clean

```
test pg_dump::t001_basic::pg_dump_help ... ok
test pg_dump::t001_basic::pg_dump_version ... ok
test pg_dump::t001_basic::pg_restore_help ... ok
test pg_dump::t001_basic::pg_restore_version ... ok

test result: ok. 4 passed; 0 failed; 59 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)