### PR TITLE
feat: implement basic pg_restore for plain-format dumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,9 +302,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -522,7 +535,9 @@ name = "pg_plumbing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
+ "futures-util",
  "tempfile",
  "thiserror",
  "tokio",
@@ -742,6 +757,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1"
+bytes = "1"
 clap = { version = "4", features = ["derive"] }
+futures-util = "0.3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7"

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -3,6 +3,7 @@
 
 //! pg_restore — restore a PostgreSQL database from an archive.
 
+use anyhow::{bail, Result};
 use clap::Parser;
 
 /// pg_restore restores a PostgreSQL database from an archive
@@ -16,7 +17,15 @@ use clap::Parser;
     about = "pg_restore restores a PostgreSQL database from an archive created by pg_dump."
 )]
 struct Cli {
-    /// Archive file to restore
+    /// Target database name or connection string.
+    #[arg(short = 'd', long = "dbname")]
+    dbname: Option<String>,
+
+    /// Drop database objects before recreating them.
+    #[arg(short = 'c', long = "clean")]
+    clean: bool,
+
+    /// Archive file to restore (positional).
     filename: Option<String>,
 }
 
@@ -25,10 +34,33 @@ fn pg_restore_version() -> &'static str {
     concat!("pg_restore (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
 }
 
-fn main() -> anyhow::Result<()> {
-    let _cli = Cli::parse();
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
 
-    // Restore logic not yet implemented.
-    eprintln!("pg_restore: not yet implemented");
-    std::process::exit(1);
+    let dbname = match cli.dbname {
+        Some(ref d) => d.clone(),
+        None => bail!("pg_restore: no database specified (use -d)"),
+    };
+
+    let filename = match cli.filename {
+        Some(ref f) => f.clone(),
+        None => bail!("pg_restore: no input file specified"),
+    };
+
+    let sql = if filename == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(&filename)?
+    };
+
+    let opts = pg_plumbing::restore::RestoreOptions {
+        dbname,
+        clean: cli.clean,
+    };
+
+    pg_plumbing::restore::restore_plain(&sql, &opts).await
 }

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -41,7 +41,7 @@ pub struct DumpOptions {
 
 /// Dump a database in plain SQL format.
 pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
-    let conninfo = build_conninfo(&opts.dbname);
+    let conninfo = crate::build_conninfo(&opts.dbname);
     let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
@@ -91,26 +91,4 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     out.push_str("--\n\n");
 
     Ok(out)
-}
-
-/// Build a libpq-style connection string from a database name.
-///
-/// If the input already looks like a connection string (contains `=`),
-/// use it as-is. Otherwise, build a minimal `host=... dbname=...` string
-/// using environment variables for host/port/user.
-fn build_conninfo(dbname: &str) -> String {
-    if dbname.contains('=') {
-        return dbname.to_string();
-    }
-
-    let host = std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string());
-    let port = std::env::var("PGPORT").unwrap_or_else(|_| "5432".to_string());
-    let user = std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string());
-    let password = std::env::var("PGPASSWORD").unwrap_or_default();
-
-    let mut s = format!("host={host} port={port} user={user} dbname={dbname}");
-    if !password.is_empty() {
-        s.push_str(&format!(" password={password}"));
-    }
-    s
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,25 @@
 
 pub mod dump;
 pub mod restore;
+
+/// Build a libpq-style connection string from a database name.
+///
+/// If the input already looks like a connection string (contains `=`),
+/// use it as-is. Otherwise, build a minimal `host=... dbname=...` string
+/// using environment variables for host/port/user.
+pub fn build_conninfo(dbname: &str) -> String {
+    if dbname.contains('=') {
+        return dbname.to_string();
+    }
+
+    let host = std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string());
+    let port = std::env::var("PGPORT").unwrap_or_else(|_| "5432".to_string());
+    let user = std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string());
+    let password = std::env::var("PGPASSWORD").unwrap_or_default();
+
+    let mut s = format!("host={host} port={port} user={user} dbname={dbname}");
+    if !password.is_empty() {
+        s.push_str(&format!(" password={password}"));
+    }
+    s
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@
 
 //! pg_plumbing — pg_dump/pg_restore rewritten in Rust.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Parser, ValueEnum};
-use pg_plumbing::dump;
+use pg_plumbing::{dump, restore};
 
 /// pg_dump/pg_restore rewritten in Rust.
 #[derive(Parser, Debug)]
@@ -19,6 +19,8 @@ struct Cli {
 enum Command {
     /// Dump a PostgreSQL database into a script file or archive.
     PgDump(PgDumpArgs),
+    /// Restore a PostgreSQL database from an archive created by pg_dump.
+    PgRestore(PgRestoreArgs),
 }
 
 /// Arguments for the pg_dump subcommand.
@@ -102,11 +104,27 @@ pub enum DumpFormat {
     Tar,
 }
 
+/// Arguments for the pg-restore subcommand.
+#[derive(Parser, Debug)]
+pub struct PgRestoreArgs {
+    /// Target database name or connection string.
+    #[arg(short = 'd', long = "dbname")]
+    dbname: Option<String>,
+
+    /// Drop database objects before recreating them.
+    #[arg(short = 'c', long = "clean")]
+    clean: bool,
+
+    /// Input archive file (positional).
+    filename: Option<String>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::PgDump(args) => run_pg_dump(args).await,
+        Command::PgRestore(args) => run_pg_restore(args).await,
     }
 }
 
@@ -140,4 +158,32 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
+    let dbname = match args.dbname {
+        Some(ref d) => d.clone(),
+        None => bail!("pg_restore: no database specified (use -d)"),
+    };
+
+    let filename = match args.filename {
+        Some(ref f) => f.clone(),
+        None => bail!("pg_restore: no input file specified"),
+    };
+
+    let sql = if filename == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(&filename)?
+    };
+
+    let opts = restore::RestoreOptions {
+        dbname,
+        clean: args.clean,
+    };
+
+    restore::restore_plain(&sql, &opts).await
 }

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -2,3 +2,212 @@
 // SPDX-License-Identifier: MIT
 
 //! pg_restore implementation.
+
+pub mod parallel;
+pub mod parse;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use futures_util::SinkExt;
+use tokio_postgres::NoTls;
+
+/// Options controlling how to restore.
+#[derive(Debug, Clone)]
+pub struct RestoreOptions {
+    /// Target database name or connection string.
+    pub dbname: String,
+    /// Drop objects before recreating them.
+    pub clean: bool,
+}
+
+/// A parsed segment of a SQL dump file.
+#[derive(Debug)]
+enum SqlSegment {
+    /// One or more regular SQL statements.
+    Statements(String),
+    /// A COPY ... FROM stdin block with its data.
+    CopyBlock {
+        /// The COPY command line (e.g. `COPY public.t (a, b) FROM stdin;`).
+        header: String,
+        /// The tab-separated data lines (without the terminating `\.`).
+        data: String,
+    },
+}
+
+/// Restore a plain-format SQL dump to a database.
+pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    if opts.clean {
+        let drop_stmts = generate_drop_statements(sql);
+        if !drop_stmts.is_empty() {
+            client
+                .batch_execute(&drop_stmts)
+                .await
+                .context("failed to execute clean (DROP) statements")?;
+        }
+    }
+
+    let segments = parse_sql_segments(sql);
+
+    for segment in &segments {
+        match segment {
+            SqlSegment::Statements(stmts) => {
+                let trimmed = stmts.trim();
+                if !trimmed.is_empty() {
+                    client.batch_execute(trimmed).await.with_context(|| {
+                        let preview: String = trimmed.chars().take(100).collect();
+                        format!("failed to execute SQL: {preview}")
+                    })?;
+                }
+            }
+            SqlSegment::CopyBlock { header, data } => {
+                let sink = client
+                    .copy_in(header.as_str())
+                    .await
+                    .with_context(|| format!("failed to start COPY: {header}"))?;
+                let mut sink = Box::pin(sink);
+                let data_bytes = Bytes::from(data.clone());
+                sink.send(data_bytes)
+                    .await
+                    .context("failed to send COPY data")?;
+                sink.close().await.context("failed to finish COPY")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse a plain-format SQL dump into executable segments.
+///
+/// Splits the input into regular SQL statement blocks and COPY FROM stdin
+/// blocks. Comment-only lines and blank lines are preserved in the
+/// statement blocks so that `batch_execute` can handle them.
+fn parse_sql_segments(sql: &str) -> Vec<SqlSegment> {
+    let mut segments = Vec::new();
+    let mut current_sql = String::new();
+    let mut in_copy = false;
+    let mut copy_header = String::new();
+    let mut copy_data = String::new();
+
+    for line in sql.lines() {
+        if in_copy {
+            if line == "\\." {
+                // End of COPY data block.
+                segments.push(SqlSegment::CopyBlock {
+                    header: copy_header.clone(),
+                    data: copy_data.clone(),
+                });
+                copy_header.clear();
+                copy_data.clear();
+                in_copy = false;
+            } else {
+                copy_data.push_str(line);
+                copy_data.push('\n');
+            }
+        } else if line.starts_with("COPY ") && line.contains("FROM stdin") && line.ends_with(';') {
+            // Flush any accumulated SQL.
+            if !current_sql.trim().is_empty() {
+                segments.push(SqlSegment::Statements(current_sql.clone()));
+                current_sql.clear();
+            }
+            copy_header = line.to_string();
+            in_copy = true;
+        } else {
+            current_sql.push_str(line);
+            current_sql.push('\n');
+        }
+    }
+
+    // Flush remaining SQL.
+    if !current_sql.trim().is_empty() {
+        segments.push(SqlSegment::Statements(current_sql));
+    }
+
+    segments
+}
+
+/// Generate DROP IF EXISTS statements for objects found in the dump SQL.
+///
+/// Scans for `CREATE TABLE` and `CREATE SEQUENCE` statements and
+/// produces corresponding `DROP ... IF EXISTS ... CASCADE;` statements.
+fn generate_drop_statements(sql: &str) -> String {
+    let mut drops = String::new();
+
+    for line in sql.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("CREATE TABLE ") {
+            if let Some(name) = rest.split(&['(', ' '][..]).next() {
+                drops.push_str(&format!("DROP TABLE IF EXISTS {name} CASCADE;\n"));
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("CREATE SEQUENCE ") {
+            if let Some(name) = rest.split(&[' ', ';'][..]).next() {
+                drops.push_str(&format!("DROP SEQUENCE IF EXISTS {name} CASCADE;\n"));
+            }
+        }
+    }
+
+    drops
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_segments_basic() {
+        let sql = "\
+SET statement_timeout = 0;
+
+CREATE TABLE public.t (id integer);
+
+COPY public.t (id) FROM stdin;
+1
+2
+3
+\\.
+
+SELECT 1;
+";
+        let segments = parse_sql_segments(sql);
+        assert_eq!(segments.len(), 3);
+        assert!(matches!(&segments[0], SqlSegment::Statements(_)));
+        assert!(matches!(&segments[1], SqlSegment::CopyBlock { .. }));
+        assert!(matches!(&segments[2], SqlSegment::Statements(_)));
+
+        if let SqlSegment::CopyBlock { header, data } = &segments[1] {
+            assert_eq!(header, "COPY public.t (id) FROM stdin;");
+            assert_eq!(data, "1\n2\n3\n");
+        }
+    }
+
+    #[test]
+    fn generate_drops_for_tables() {
+        let sql = "\
+CREATE TABLE public.foo (id integer);
+CREATE TABLE public.bar (name text);
+CREATE SEQUENCE public.foo_id_seq;
+";
+        let drops = generate_drop_statements(sql);
+        assert!(drops.contains("DROP TABLE IF EXISTS public.foo CASCADE;"));
+        assert!(drops.contains("DROP TABLE IF EXISTS public.bar CASCADE;"));
+        assert!(drops.contains("DROP SEQUENCE IF EXISTS public.foo_id_seq CASCADE;"));
+    }
+
+    #[test]
+    fn generate_drops_empty_for_comments() {
+        let sql = "-- just a comment\nSET x = 1;\n";
+        let drops = generate_drop_statements(sql);
+        assert!(drops.is_empty());
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 pg_plumbing contributors
 // SPDX-License-Identifier: MIT
 
-//! Shared test helpers for pg_dump integration tests.
+//! Shared test helpers for pg_dump/pg_restore integration tests.
 
 use std::process::Command;
 
@@ -47,6 +47,20 @@ pub fn run_pg_dump(args: &[&str]) -> (String, String, i32) {
     (stdout, stderr, code)
 }
 
+/// Run pg_plumbing pg-restore with the given arguments.
+/// Returns (stdout, stderr, exit_code).
+pub fn run_pg_restore(args: &[&str]) -> (String, String, i32) {
+    let bin = pg_plumbing_bin();
+    let mut cmd = Command::new(&bin);
+    cmd.arg("pg-restore");
+    cmd.args(args);
+    let output = cmd.output().expect("failed to execute pg_plumbing");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let code = output.status.code().unwrap_or(-1);
+    (stdout, stderr, code)
+}
+
 /// Set up the test database schema. Idempotent.
 /// Uses OnceLock to avoid Once poisoning when setup fails.
 pub fn setup_test_schema() {
@@ -80,4 +94,126 @@ pub fn setup_test_schema() {
             String::from_utf8_lossy(&output.stderr)
         );
     });
+}
+
+/// Run a SQL command via psql against the given database.
+/// Panics on failure.
+pub fn psql(dbname: &str, sql: &str) {
+    let conninfo = test_conninfo(dbname);
+    let password = std::env::var("PGPASSWORD").unwrap_or_default();
+    let mut cmd = Command::new("psql");
+    cmd.arg(&conninfo).arg("-c").arg(sql);
+    if !password.is_empty() {
+        cmd.env("PGPASSWORD", &password);
+    }
+    let output = cmd.output().expect("psql failed");
+    assert!(
+        output.status.success(),
+        "psql command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Run a SQL query via psql and return the output (tuples-only, no alignment).
+pub fn psql_query(dbname: &str, sql: &str) -> String {
+    let conninfo = test_conninfo(dbname);
+    let password = std::env::var("PGPASSWORD").unwrap_or_default();
+    let mut cmd = Command::new("psql");
+    cmd.arg(&conninfo)
+        .arg("-tA") // tuples only, unaligned
+        .arg("-c")
+        .arg(sql);
+    if !password.is_empty() {
+        cmd.env("PGPASSWORD", &password);
+    }
+    let output = cmd.output().expect("psql query failed");
+    assert!(
+        output.status.success(),
+        "psql query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// Create a fresh test database. Drops it first if it exists.
+pub fn create_test_db(dbname: &str) {
+    drop_test_db(dbname);
+
+    let conninfo = test_conninfo("postgres");
+    let password = std::env::var("PGPASSWORD").unwrap_or_default();
+    let create_sql = format!("create database \"{dbname}\";");
+    let mut cmd = Command::new("psql");
+    cmd.arg(&conninfo).arg("-c").arg(&create_sql);
+    if !password.is_empty() {
+        cmd.env("PGPASSWORD", &password);
+    }
+    let output = cmd.output().expect("create database failed");
+    assert!(
+        output.status.success(),
+        "create database failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Set up a simple restore-test table (no SERIAL/sequence dependency).
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_restore_test_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+        let sql = "\
+            drop table if exists dump_test_restore cascade;\n\
+            create table dump_test_restore (\n\
+                id integer not null,\n\
+                name text not null,\n\
+                value integer,\n\
+                constraint dump_test_restore_pkey primary key (id)\n\
+            );\n\
+            insert into dump_test_restore (id, name, value) values\n\
+                (1, 'alice', 10),\n\
+                (2, 'bob', 20),\n\
+                (3, 'charlie', 30);\n\
+        ";
+        let mut cmd = Command::new("psql");
+        cmd.arg(&conninfo).arg("-c").arg(sql);
+        if !password.is_empty() {
+            cmd.env("PGPASSWORD", &password);
+        }
+        let output = cmd.output().expect("psql setup_restore failed");
+        assert!(
+            output.status.success(),
+            "setup_restore failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    });
+}
+
+/// Drop a test database if it exists.
+pub fn drop_test_db(dbname: &str) {
+    let conninfo = test_conninfo("postgres");
+    let password = std::env::var("PGPASSWORD").unwrap_or_default();
+
+    // Terminate connections first.
+    let term_sql = format!(
+        "select pg_terminate_backend(pid) \
+         from pg_stat_activity \
+         where datname = '{dbname}' and pid <> pg_backend_pid();"
+    );
+    let mut cmd = Command::new("psql");
+    cmd.arg(&conninfo).arg("-c").arg(&term_sql);
+    if !password.is_empty() {
+        cmd.env("PGPASSWORD", &password);
+    }
+    let _ = cmd.output();
+
+    // Now drop.
+    let drop_sql = format!("drop database if exists \"{dbname}\";");
+    let mut cmd = Command::new("psql");
+    cmd.arg(&conninfo).arg("-c").arg(&drop_sql);
+    if !password.is_empty() {
+        cmd.env("PGPASSWORD", &password);
+    }
+    let _ = cmd.output();
 }

--- a/tests/pg_restore/mod.rs
+++ b/tests/pg_restore/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for pg_restore functionality.
+
+mod restore_basic;

--- a/tests/pg_restore/restore_basic.rs
+++ b/tests/pg_restore/restore_basic.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! Basic pg_restore integration tests: dump -> restore -> verify round-trip.
+
+#[test]
+/// Dump a table, restore to a different database, verify data matches.
+fn restore_plain_dump_round_trip() {
+    crate::common::setup_restore_test_schema();
+
+    // Dump the test table to a file.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dump_path = dir.path().join("dump.sql");
+    let dump_path_str = dump_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_restore",
+        "-d",
+        "postgres",
+        "-f",
+        &dump_path_str,
+    ]);
+    assert_eq!(code, 0, "pg_dump failed: {stderr}");
+
+    // Create a fresh target database.
+    let target_db = "pg_plumbing_restore_test";
+    crate::common::create_test_db(target_db);
+
+    // Restore the dump into the target database.
+    let (_stdout, stderr, code) = crate::common::run_pg_restore(&["-d", target_db, &dump_path_str]);
+    assert_eq!(code, 0, "pg_restore failed: {stderr}");
+
+    // Verify data matches.
+    let source_data = crate::common::psql_query(
+        "postgres",
+        "select id, name, value from public.dump_test_restore order by id;",
+    );
+    let target_data = crate::common::psql_query(
+        target_db,
+        "select id, name, value from public.dump_test_restore order by id;",
+    );
+    assert_eq!(
+        source_data, target_data,
+        "restored data should match source"
+    );
+
+    // Verify row count.
+    let count =
+        crate::common::psql_query(target_db, "select count(*) from public.dump_test_restore;");
+    assert_eq!(count.trim(), "3", "should have 3 rows");
+
+    // Clean up.
+    crate::common::drop_test_db(target_db);
+}
+
+#[test]
+/// Restore with --clean drops and recreates objects.
+fn restore_with_clean_flag() {
+    crate::common::setup_restore_test_schema();
+
+    // Dump the test table.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dump_path = dir.path().join("dump.sql");
+    let dump_path_str = dump_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_restore",
+        "-d",
+        "postgres",
+        "-f",
+        &dump_path_str,
+    ]);
+    assert_eq!(code, 0, "pg_dump failed: {stderr}");
+
+    // Create target database and populate with conflicting table.
+    let target_db = "pg_plumbing_restore_clean_test";
+    crate::common::create_test_db(target_db);
+    crate::common::psql(
+        target_db,
+        "create table public.dump_test_restore (id integer);",
+    );
+
+    // Restore with --clean should drop existing table and recreate.
+    let (_stdout, stderr, code) =
+        crate::common::run_pg_restore(&["-d", target_db, "--clean", &dump_path_str]);
+    assert_eq!(code, 0, "pg_restore --clean failed: {stderr}");
+
+    // Verify data is correct.
+    let count =
+        crate::common::psql_query(target_db, "select count(*) from public.dump_test_restore;");
+    assert_eq!(count.trim(), "3", "should have 3 rows after clean restore");
+
+    // Clean up.
+    crate::common::drop_test_db(target_db);
+}
+
+#[test]
+/// Restore from stdin using "-" as filename.
+fn restore_from_stdin() {
+    crate::common::setup_restore_test_schema();
+
+    // Dump the test table to a file first.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dump_path = dir.path().join("dump.sql");
+    let dump_path_str = dump_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_restore",
+        "-d",
+        "postgres",
+        "-f",
+        &dump_path_str,
+    ]);
+    assert_eq!(code, 0, "pg_dump failed: {stderr}");
+
+    // Create target database.
+    let target_db = "pg_plumbing_restore_stdin_test";
+    crate::common::create_test_db(target_db);
+
+    // Restore by piping dump file through stdin.
+    let bin = crate::common::pg_plumbing_bin();
+    let dump_sql = std::fs::read(&dump_path).expect("read dump file");
+
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.arg("pg-restore")
+        .arg("-d")
+        .arg(target_db)
+        .arg("-")
+        .stdin(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn pg_restore");
+    {
+        use std::io::Write;
+        let stdin = child.stdin.as_mut().expect("stdin");
+        stdin.write_all(&dump_sql).expect("write stdin");
+    }
+    let output = child.wait_with_output().expect("wait");
+    assert!(
+        output.status.success(),
+        "pg_restore from stdin failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify data.
+    let count =
+        crate::common::psql_query(target_db, "select count(*) from public.dump_test_restore;");
+    assert_eq!(count.trim(), "3", "should have 3 rows");
+
+    // Clean up.
+    crate::common::drop_test_db(target_db);
+}
+
+#[test]
+/// pg_restore without -d flag fails with an error message.
+fn restore_requires_dbname() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("dummy.sql");
+    std::fs::write(&path, "SELECT 1;").expect("write");
+
+    let (_stdout, stderr, code) = crate::common::run_pg_restore(&[&path.to_string_lossy()]);
+    assert_ne!(code, 0, "should fail without -d");
+    assert!(
+        stderr.contains("no database specified"),
+        "should mention missing database: {stderr}"
+    );
+}
+
+#[test]
+/// pg_restore without a filename fails with an error message.
+fn restore_requires_filename() {
+    let (_stdout, stderr, code) = crate::common::run_pg_restore(&["-d", "postgres"]);
+    assert_ne!(code, 0, "should fail without filename");
+    assert!(
+        stderr.contains("no input file specified"),
+        "should mention missing filename: {stderr}"
+    );
+}
+
+#[test]
+/// Restore a dump with INSERT statements (not COPY).
+fn restore_inserts_mode_round_trip() {
+    crate::common::setup_restore_test_schema();
+
+    // Dump with --inserts.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dump_path = dir.path().join("dump_inserts.sql");
+    let dump_path_str = dump_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_restore",
+        "-d",
+        "postgres",
+        "--inserts",
+        "-f",
+        &dump_path_str,
+    ]);
+    assert_eq!(code, 0, "pg_dump --inserts failed: {stderr}");
+
+    // Verify dump uses INSERT not COPY.
+    let dump_content = std::fs::read_to_string(&dump_path).expect("read dump");
+    assert!(
+        dump_content.contains("INSERT INTO"),
+        "dump should use INSERT statements"
+    );
+
+    // Create target and restore.
+    let target_db = "pg_plumbing_restore_inserts_test";
+    crate::common::create_test_db(target_db);
+
+    let (_stdout, stderr, code) = crate::common::run_pg_restore(&["-d", target_db, &dump_path_str]);
+    assert_eq!(code, 0, "pg_restore (inserts) failed: {stderr}");
+
+    // Verify data.
+    let source_data = crate::common::psql_query(
+        "postgres",
+        "select id, name, value from public.dump_test_restore order by id;",
+    );
+    let target_data = crate::common::psql_query(
+        target_db,
+        "select id, name, value from public.dump_test_restore order by id;",
+    );
+    assert_eq!(
+        source_data, target_data,
+        "restored INSERT data should match source"
+    );
+
+    // Clean up.
+    crate::common::drop_test_db(target_db);
+}

--- a/tests/pg_restore_tests.rs
+++ b/tests/pg_restore_tests.rs
@@ -1,0 +1,7 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for pg_restore.
+
+mod common;
+mod pg_restore;


### PR DESCRIPTION
## Summary

- Implement `pg_restore` that reads plain-format SQL dump files and restores them to a target PostgreSQL database
- Support `-d`/`--dbname`, `--clean` (drop objects first), and stdin input via `"-"`
- Handle both COPY FROM stdin protocol and INSERT-based dumps
- Refactor `build_conninfo` into shared `lib.rs` for reuse by both dump and restore
- Add `pg-restore` subcommand to the `pg_plumbing` multi-tool binary
- Add 6 new integration tests (dump → restore → verify round-trip)

All 18 tests pass (12 existing + 6 new), clippy clean, fmt clean.

Closes #5

## Test plan

- [x] `cargo test` — all 18 tests pass (12 existing + 6 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Round-trip: dump table → restore to different DB → verify data matches
- [x] `--clean` flag: restore over existing conflicting table
- [x] stdin input: pipe dump through stdin with `"-"` filename
- [x] INSERT mode: dump with `--inserts`, restore, verify data
- [x] Error handling: missing `-d` flag, missing filename

<details>
<summary>Test output</summary>

```
running 8 tests  (unit)
test dump::catalog::tests::* ... ok (4)
test dump::format::tests::escape_copy_value_basic ... ok
test restore::tests::* ... ok (3)

running 294 tests  (pg_dump integration)
test result: ok. 12 passed; 0 failed; 282 ignored

running 6 tests  (pg_restore integration)
test pg_restore::restore_basic::restore_plain_dump_round_trip ... ok
test pg_restore::restore_basic::restore_with_clean_flag ... ok
test pg_restore::restore_basic::restore_from_stdin ... ok
test pg_restore::restore_basic::restore_requires_dbname ... ok
test pg_restore::restore_basic::restore_requires_filename ... ok
test pg_restore::restore_basic::restore_inserts_mode_round_trip ... ok
test result: ok. 6 passed; 0 failed
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)