### PR TITLE
feat: CLI flag validation (conflict detection) (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ name = "pg_restore"
 path = "src/bin/pg_restore.rs"
 
 [[bin]]
+name = "pg_dumpall"
+path = "src/bin/pg_dumpall.rs"
+
+[[bin]]
 name = "pg_plumbing"
 path = "src/main.rs"
 

--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -15,8 +15,77 @@ use clap::Parser;
     about = "pg_dump dumps a database as a text file or to other formats."
 )]
 struct Cli {
-    /// Database name to dump
-    dbname: Option<String>,
+    /// Database name to dump (positional, alternative to -d)
+    #[arg()]
+    dbname: Vec<String>,
+
+    /// Database name or connection string
+    #[arg(short = 'd', long = "dbname")]
+    dbname_flag: Option<String>,
+
+    /// Output format: plain (p), custom (c), directory (d), tar (t)
+    #[arg(short = 'F', long = "format")]
+    format: Option<String>,
+
+    /// Output file or directory name
+    #[arg(short = 'f', long = "file")]
+    file: Option<String>,
+
+    /// Dump only the schema (no data)
+    #[arg(short = 's', long = "schema-only")]
+    schema_only: bool,
+
+    /// Dump only the data (no schema)
+    #[arg(short = 'a', long = "data-only")]
+    data_only: bool,
+
+    /// Dump only statistics (no schema or data)
+    #[arg(long = "statistics-only")]
+    statistics_only: bool,
+
+    /// Do not dump statistics
+    #[arg(long = "no-statistics")]
+    no_statistics: bool,
+
+    /// Include foreign-server data
+    #[arg(long = "include-foreign-data")]
+    include_foreign_data: Option<String>,
+
+    /// Drop database objects before recreating them
+    #[arg(short = 'c', long = "clean")]
+    clean: bool,
+
+    /// Use DROP ... IF EXISTS
+    #[arg(long = "if-exists")]
+    if_exists: bool,
+
+    /// Number of parallel jobs for directory format
+    #[arg(short = 'j', long = "jobs", allow_negative_numbers = true)]
+    jobs: Option<String>,
+
+    /// Compression specification (algorithm[:level] or just level)
+    #[arg(short = 'Z', long = "compress")]
+    compress: Option<String>,
+
+    /// Extra float digits
+    #[arg(long = "extra-float-digits", allow_negative_numbers = true)]
+    extra_float_digits: Option<i64>,
+
+    /// Rows per INSERT statement
+    #[arg(long = "rows-per-insert")]
+    rows_per_insert: Option<i64>,
+
+    /// Use INSERT commands instead of COPY
+    #[arg(long = "inserts")]
+    inserts: bool,
+
+    /// Use INSERT commands with column names
+    #[arg(long = "column-inserts")]
+    column_inserts: bool,
+
+    /// Add ON CONFLICT DO NOTHING to INSERT commands
+    #[arg(long = "on-conflict-do-nothing")]
+    on_conflict_do_nothing: bool,
 }
 
 /// Build the version string: `pg_dump (pg_plumbing) <version>`.
@@ -24,10 +93,260 @@ fn pg_dump_version() -> &'static str {
     concat!("pg_dump (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
 }
 
-fn main() -> anyhow::Result<()> {
-    let _cli = Cli::parse();
+fn validate_format(fmt: &str) -> bool {
+    matches!(
+        fmt,
+        "plain" | "p" | "custom" | "c" | "directory" | "d" | "tar" | "t"
+    )
+}
 
-    // Dump logic not yet implemented.
+fn main() {
+    let cli = Cli::parse();
+
+    // Too many positional args
+    if cli.dbname.len() > 1 {
+        eprintln!(
+            "pg_dump: too many command-line arguments (first is \"{}\")",
+            cli.dbname[1]
+        );
+        std::process::exit(1);
+    }
+
+    // Validate format if provided
+    if let Some(ref fmt) = cli.format {
+        if !validate_format(fmt) {
+            eprintln!("pg_dump: invalid output format \"{fmt}\"");
+            std::process::exit(1);
+        }
+    }
+
+    let format_str = cli.format.as_deref().unwrap_or("plain");
+
+    // --schema-only + --data-only
+    if cli.schema_only && cli.data_only {
+        eprintln!("pg_dump: options -s/--schema-only and -a/--data-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --schema-only + --statistics-only
+    if cli.schema_only && cli.statistics_only {
+        eprintln!(
+            "pg_dump: options -s/--schema-only and --statistics-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --data-only + --statistics-only
+    if cli.data_only && cli.statistics_only {
+        eprintln!("pg_dump: options -a/--data-only and --statistics-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --statistics-only + --no-statistics
+    if cli.statistics_only && cli.no_statistics {
+        eprintln!("pg_dump: options --statistics-only and --no-statistics cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --include-foreign-data + --schema-only
+    if cli.include_foreign_data.is_some() && cli.schema_only {
+        eprintln!(
+            "pg_dump: options --include-foreign-data and -s/--schema-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --include-foreign-data + -j
+    if cli.include_foreign_data.is_some() && cli.jobs.is_some() {
+        eprintln!("pg_dump: options --include-foreign-data and --jobs cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --clean + --data-only
+    if cli.clean && cli.data_only {
+        eprintln!("pg_dump: options -c/--clean and -a/--data-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --if-exists requires --clean
+    if cli.if_exists && !cli.clean {
+        eprintln!("pg_dump: option --if-exists requires option -c/--clean");
+        std::process::exit(1);
+    }
+
+    // --on-conflict-do-nothing requires --inserts, --rows-per-insert, or --column-inserts
+    if cli.on_conflict_do_nothing
+        && !cli.inserts
+        && !cli.column_inserts
+        && cli.rows_per_insert.is_none()
+    {
+        eprintln!(
+            "pg_dump: option --on-conflict-do-nothing requires option --inserts, --column-inserts, or --rows-per-insert"
+        );
+        std::process::exit(1);
+    }
+
+    // Validate jobs
+    if let Some(ref jobs_str) = cli.jobs {
+        match jobs_str.parse::<i64>() {
+            Ok(n) if !(1..=1000).contains(&n) => {
+                eprintln!("pg_dump: invalid number of parallel jobs: {n}");
+                std::process::exit(1);
+            }
+            Err(_) => {
+                eprintln!("pg_dump: invalid number of parallel jobs: \"{jobs_str}\"");
+                std::process::exit(1);
+            }
+            Ok(_) => {}
+        }
+
+        // -j requires directory format
+        let is_directory = matches!(format_str, "directory" | "d");
+        if !is_directory {
+            eprintln!("pg_dump: parallel backup only supported by the directory format");
+            std::process::exit(1);
+        }
+    }
+
+    // Validate --compress
+    if let Some(ref compress_str) = cli.compress {
+        validate_compress(compress_str, format_str);
+    }
+
+    // --extra-float-digits range: -15 to 3
+    if let Some(v) = cli.extra_float_digits {
+        if !(-15..=3).contains(&v) {
+            eprintln!("pg_dump: --extra-float-digits must be in range -15..3, got {v}");
+            std::process::exit(1);
+        }
+    }
+
+    // --rows-per-insert must be >= 1
+    if let Some(v) = cli.rows_per_insert {
+        if v < 1 {
+            eprintln!("pg_dump: --rows-per-insert must be a value >= 1");
+            std::process::exit(1);
+        }
+    }
+
+    // Actual dump not yet implemented.
     eprintln!("pg_dump: not yet implemented");
     std::process::exit(1);
+}
+
+fn validate_compress(compress_str: &str, format_str: &str) {
+    // Compression is not supported by tar format
+    let is_tar = matches!(format_str, "tar" | "t");
+
+    // Parse compress spec: algorithm[:level] or just integer level
+    // Allowed algorithms: gzip, zstd, lz4, none, zlib
+    let has_colon = compress_str.contains(':');
+    let starts_with_digit = compress_str
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_digit() || c == '-');
+
+    let (algorithm, level_str): (Option<&str>, Option<&str>) = if has_colon {
+        let idx = compress_str.find(':').unwrap();
+        let alg = &compress_str[..idx];
+        let lvl = &compress_str[idx + 1..];
+        (Some(alg), Some(lvl))
+    } else if starts_with_digit {
+        // pure integer (old -Z N style)
+        (None, Some(compress_str))
+    } else {
+        // pure algorithm name, no level
+        (Some(compress_str), None)
+    };
+
+    if let Some(alg) = algorithm {
+        let valid_algorithms = ["gzip", "zstd", "lz4", "none", "zlib", ""];
+        if !valid_algorithms.contains(&alg) {
+            eprintln!("pg_dump: unrecognized compression algorithm: \"{alg}\"");
+            std::process::exit(1);
+        }
+
+        // "none" does not accept a compression level > 0
+        if alg == "none" {
+            if let Some(lvl) = level_str {
+                match lvl.parse::<i64>() {
+                    Ok(n) if n > 0 => {
+                        eprintln!(
+                            "pg_dump: compression algorithm \"none\" does not accept a compression level"
+                        );
+                        std::process::exit(1);
+                    }
+                    Err(_) if !lvl.is_empty() => {
+                        eprintln!(
+                            "pg_dump: invalid compression level \"{lvl}\" for algorithm \"none\""
+                        );
+                        std::process::exit(1);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // gzip / zlib level must be 0-9
+        if alg == "gzip" || alg == "zlib" {
+            if let Some(lvl) = level_str {
+                match lvl.parse::<i64>() {
+                    Ok(n) if !(0..=9).contains(&n) => {
+                        eprintln!("pg_dump: compression level {n} is out of range (0..9) for gzip");
+                        std::process::exit(1);
+                    }
+                    Err(_) => {
+                        eprintln!(
+                            "pg_dump: invalid compression level \"{lvl}\" for algorithm \"{alg}\""
+                        );
+                        std::process::exit(1);
+                    }
+                    Ok(_) => {}
+                }
+            }
+        }
+
+        // Tar format doesn't support compression
+        if is_tar && alg != "none" && !alg.is_empty() {
+            if let Some(lvl) = level_str {
+                match lvl.parse::<i64>() {
+                    Ok(n) if n > 0 => {
+                        eprintln!("pg_dump: compression is not supported by tar archive format");
+                        std::process::exit(1);
+                    }
+                    _ => {}
+                }
+            } else {
+                // algorithm specified without level means use default compression
+                eprintln!("pg_dump: compression is not supported by tar archive format");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        // Old-style: just a level integer (implies gzip)
+        if let Some(lvl) = level_str {
+            match lvl.parse::<i64>() {
+                Ok(n) if !(0..=9).contains(&n) => {
+                    eprintln!("pg_dump: compression level {n} is out of range (0..9) for gzip");
+                    std::process::exit(1);
+                }
+                Err(_) => {
+                    eprintln!("pg_dump: invalid compression level \"{lvl}\"");
+                    std::process::exit(1);
+                }
+                Ok(_) => {}
+            }
+
+            // Tar format doesn't support compression
+            if is_tar {
+                match lvl.parse::<i64>() {
+                    Ok(n) if n > 0 => {
+                        eprintln!("pg_dump: compression is not supported by tar archive format");
+                        std::process::exit(1);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 }

--- a/src/bin/pg_dumpall.rs
+++ b/src/bin/pg_dumpall.rs
@@ -1,0 +1,226 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! pg_dumpall — dump all PostgreSQL databases.
+
+use clap::Parser;
+
+/// pg_dumpall extracts a PostgreSQL database cluster into an SQL script file.
+///
+/// Compatible with PostgreSQL's pg_dumpall.
+#[derive(Parser)]
+#[command(
+    name = "pg_dumpall",
+    version = pg_dumpall_version(),
+    about = "pg_dumpall extracts a PostgreSQL database cluster into an SQL script file."
+)]
+struct Cli {
+    /// Positional arguments (should be empty)
+    #[arg()]
+    extra_args: Vec<String>,
+
+    /// Drop database objects before recreating them
+    #[arg(short = 'c', long = "clean")]
+    clean: bool,
+
+    /// Use DROP ... IF EXISTS
+    #[arg(long = "if-exists")]
+    if_exists: bool,
+
+    /// Dump only the data (no schema)
+    #[arg(short = 'a', long = "data-only")]
+    data_only: bool,
+
+    /// Dump only the schema (no data)
+    #[arg(short = 's', long = "schema-only")]
+    schema_only: bool,
+
+    /// Dump only statistics
+    #[arg(long = "statistics-only")]
+    statistics_only: bool,
+
+    /// Do not dump statistics
+    #[arg(long = "no-statistics")]
+    no_statistics: bool,
+
+    /// Dump only global objects
+    #[arg(short = 'g', long = "globals-only")]
+    globals_only: bool,
+
+    /// Dump only roles
+    #[arg(short = 'r', long = "roles-only")]
+    roles_only: bool,
+
+    /// Dump only tablespaces
+    #[arg(short = 't', long = "tablespaces-only")]
+    tablespaces_only: bool,
+
+    /// Exclude database matching pattern
+    #[arg(long = "exclude-database")]
+    exclude_database: Option<String>,
+
+    /// Output format: plain (p), custom (c), directory (d), tar (t)
+    #[arg(long = "format")]
+    format: Option<String>,
+
+    /// Output file or directory
+    #[arg(short = 'f', long = "file")]
+    file: Option<String>,
+
+    /// Do not dump data
+    #[arg(long = "no-data")]
+    no_data: bool,
+
+    /// Do not dump schema
+    #[arg(long = "no-schema")]
+    no_schema: bool,
+
+    /// Include statistics in dump
+    #[arg(long = "statistics")]
+    statistics: bool,
+
+    /// Restrict key for dump (only with --format=plain)
+    #[arg(long = "restrict-key")]
+    restrict_key: Option<String>,
+}
+
+/// Build the version string: `pg_dumpall (pg_plumbing) <version>`.
+fn pg_dumpall_version() -> &'static str {
+    concat!("pg_dumpall (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
+}
+
+fn validate_format(fmt: &str) -> bool {
+    matches!(
+        fmt,
+        "plain" | "p" | "custom" | "c" | "directory" | "d" | "tar" | "t"
+    )
+}
+
+fn is_plain_format(fmt: &str) -> bool {
+    matches!(fmt, "plain" | "p")
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    // Too many positional args
+    if cli.extra_args.len() > 1 {
+        eprintln!(
+            "pg_dumpall: too many command-line arguments (first is \"{}\")",
+            cli.extra_args[1]
+        );
+        std::process::exit(1);
+    }
+
+    // Validate format if provided
+    if let Some(ref fmt) = cli.format {
+        if !validate_format(fmt) {
+            eprintln!("pg_dumpall: invalid output format \"{fmt}\"");
+            std::process::exit(1);
+        }
+    }
+
+    let format_str = cli.format.as_deref().unwrap_or("plain");
+
+    // --clean + --data-only
+    if cli.clean && cli.data_only {
+        eprintln!("pg_dumpall: options -c/--clean and -a/--data-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --globals-only + --roles-only
+    if cli.globals_only && cli.roles_only {
+        eprintln!(
+            "pg_dumpall: options -g/--globals-only and -r/--roles-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --globals-only + --tablespaces-only
+    if cli.globals_only && cli.tablespaces_only {
+        eprintln!(
+            "pg_dumpall: options -g/--globals-only and -t/--tablespaces-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --roles-only + --tablespaces-only
+    if cli.roles_only && cli.tablespaces_only {
+        eprintln!(
+            "pg_dumpall: options -r/--roles-only and -t/--tablespaces-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --if-exists requires --clean
+    if cli.if_exists && !cli.clean {
+        eprintln!("pg_dumpall: option --if-exists requires option -c/--clean");
+        std::process::exit(1);
+    }
+
+    // --exclude-database + --globals-only
+    if cli.exclude_database.is_some() && cli.globals_only {
+        eprintln!(
+            "pg_dumpall: options --exclude-database and --globals-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --data-only + --no-data
+    if cli.data_only && cli.no_data {
+        eprintln!("pg_dumpall: options -a/--data-only and --no-data cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --schema-only + --no-schema
+    if cli.schema_only && cli.no_schema {
+        eprintln!("pg_dumpall: options -s/--schema-only and --no-schema cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --statistics-only + --no-statistics
+    if cli.statistics_only && cli.no_statistics {
+        eprintln!(
+            "pg_dumpall: options --statistics-only and --no-statistics cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --statistics + --no-statistics
+    if cli.statistics && cli.no_statistics {
+        eprintln!("pg_dumpall: options --statistics and --no-statistics cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --statistics + --tablespaces-only
+    if cli.statistics && cli.tablespaces_only {
+        eprintln!(
+            "pg_dumpall: options --statistics and -t/--tablespaces-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --restrict-key can only be used with --format=plain
+    if cli.restrict_key.is_some() && !is_plain_format(format_str) {
+        eprintln!("pg_dumpall: option --restrict-key can only be used with --format=plain");
+        std::process::exit(1);
+    }
+
+    // --clean + --globals-only in non-plain format
+    if cli.clean && cli.globals_only && !is_plain_format(format_str) {
+        eprintln!(
+            "pg_dumpall: options -c/--clean and --globals-only cannot be used together in non-plain format"
+        );
+        std::process::exit(1);
+    }
+
+    // Non-plain format requires --file
+    if !is_plain_format(format_str) && cli.file.is_none() {
+        eprintln!("pg_dumpall: non-plain output format requires -f/--file option");
+        std::process::exit(1);
+    }
+
+    // Actual dump not yet implemented.
+    eprintln!("pg_dumpall: not yet implemented");
+    std::process::exit(1);
+}

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -3,7 +3,6 @@
 
 //! pg_restore — restore a PostgreSQL database from an archive.
 
-use anyhow::{bail, Result};
 use clap::Parser;
 
 /// pg_restore restores a PostgreSQL database from an archive
@@ -21,12 +20,61 @@ struct Cli {
     #[arg(short = 'd', long = "dbname")]
     dbname: Option<String>,
 
+    /// Output file/script (use - for stdout)
+    #[arg(short = 'f', long = "file")]
+    file: Option<String>,
+
     /// Drop database objects before recreating them.
     #[arg(short = 'c', long = "clean")]
     clean: bool,
 
-    /// Archive file to restore (positional).
-    filename: Option<String>,
+    /// Use DROP ... IF EXISTS
+    #[arg(long = "if-exists")]
+    if_exists: bool,
+
+    /// Dump only the data (no schema)
+    #[arg(short = 'a', long = "data-only")]
+    data_only: bool,
+
+    /// Dump only the schema (no data)
+    #[arg(short = 's', long = "schema-only")]
+    schema_only: bool,
+
+    /// Dump only statistics
+    #[arg(long = "statistics-only")]
+    statistics_only: bool,
+
+    /// Number of parallel jobs
+    #[arg(short = 'j', long = "jobs", allow_negative_numbers = true)]
+    jobs: Option<String>,
+
+    /// Restore in a single transaction
+    #[arg(short = '1', long = "single-transaction")]
+    single_transaction: bool,
+
+    /// Archive format
+    #[arg(short = 'F', long = "format")]
+    format: Option<String>,
+
+    /// Create the target database
+    #[arg(short = 'C', long = "create")]
+    create: bool,
+
+    /// Exclude databases matching pattern (dumpall only)
+    #[arg(long = "exclude-database")]
+    exclude_database: Option<String>,
+
+    /// Restore only global objects
+    #[arg(short = 'g', long = "globals-only")]
+    globals_only: bool,
+
+    /// Do not restore global objects
+    #[arg(long = "no-globals")]
+    no_globals: bool,
+
+    /// Archive file(s) to restore (positional).
+    #[arg()]
+    filenames: Vec<String>,
 }
 
 /// Build the version string: `pg_restore (pg_plumbing) <version>`.
@@ -34,33 +82,151 @@ fn pg_restore_version() -> &'static str {
     concat!("pg_restore (pg_plumbing) ", env!("CARGO_PKG_VERSION"))
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() {
     let cli = Cli::parse();
 
-    let dbname = match cli.dbname {
-        Some(ref d) => d.clone(),
-        None => bail!("pg_restore: no database specified (use -d)"),
-    };
+    // Too many positional args (more than 1 file)
+    if cli.filenames.len() > 1 {
+        eprintln!(
+            "pg_restore: too many command-line arguments (first is \"{}\")",
+            cli.filenames[1]
+        );
+        std::process::exit(1);
+    }
 
-    let filename = match cli.filename {
-        Some(ref f) => f.clone(),
-        None => bail!("pg_restore: no input file specified"),
-    };
+    // Validate format if provided
+    if let Some(ref fmt) = cli.format {
+        if fmt.is_empty() {
+            eprintln!("pg_restore: invalid archive format \"\"");
+            std::process::exit(1);
+        }
+        if !validate_format(fmt) {
+            eprintln!("pg_restore: invalid archive format \"{fmt}\"");
+            std::process::exit(1);
+        }
+    }
 
-    let sql = if filename == "-" {
-        use std::io::Read;
-        let mut buf = String::new();
-        std::io::stdin().read_to_string(&mut buf)?;
-        buf
-    } else {
-        std::fs::read_to_string(&filename)?
-    };
+    // --data-only + --schema-only
+    if cli.data_only && cli.schema_only {
+        eprintln!(
+            "pg_restore: options -a/--data-only and -s/--schema-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
 
-    let opts = pg_plumbing::restore::RestoreOptions {
-        dbname,
-        clean: cli.clean,
-    };
+    // -d and -f cannot be used together
+    if cli.dbname.is_some() && cli.file.is_some() {
+        eprintln!("pg_restore: options -d/--dbname and -f/--file cannot be used together");
+        std::process::exit(1);
+    }
 
-    pg_plumbing::restore::restore_plain(&sql, &opts).await
+    // --clean + --data-only
+    if cli.clean && cli.data_only {
+        eprintln!("pg_restore: options -c/--clean and -a/--data-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --if-exists requires --clean
+    if cli.if_exists && !cli.clean {
+        eprintln!("pg_restore: option --if-exists requires option -c/--clean");
+        std::process::exit(1);
+    }
+
+    // Validate jobs
+    if let Some(ref jobs_str) = cli.jobs {
+        match jobs_str.parse::<i64>() {
+            Ok(n) if !(1..=1000).contains(&n) => {
+                eprintln!("pg_restore: invalid number of parallel jobs: {n}");
+                std::process::exit(1);
+            }
+            Err(_) => {
+                eprintln!("pg_restore: invalid number of parallel jobs: \"{jobs_str}\"");
+                std::process::exit(1);
+            }
+            Ok(_) => {}
+        }
+    }
+
+    // --single-transaction + -j
+    if cli.single_transaction && cli.jobs.is_some() {
+        eprintln!("pg_restore: options --single-transaction and --jobs cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --create + --single-transaction
+    if cli.create && cli.single_transaction {
+        eprintln!(
+            "pg_restore: options -C/--create and -1/--single-transaction cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --exclude-database + --globals-only
+    if cli.exclude_database.is_some() && cli.globals_only {
+        eprintln!(
+            "pg_restore: options --exclude-database and --globals-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --data-only + --globals-only
+    if cli.data_only && cli.globals_only {
+        eprintln!("pg_restore: options -a/--data-only and --globals-only cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --globals-only + --schema-only
+    if cli.globals_only && cli.schema_only {
+        eprintln!(
+            "pg_restore: options --globals-only and -s/--schema-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --globals-only + --statistics-only
+    if cli.globals_only && cli.statistics_only {
+        eprintln!(
+            "pg_restore: options --globals-only and --statistics-only cannot be used together"
+        );
+        std::process::exit(1);
+    }
+
+    // --globals-only + --no-globals
+    if cli.globals_only && cli.no_globals {
+        eprintln!("pg_restore: options --globals-only and --no-globals cannot be used together");
+        std::process::exit(1);
+    }
+
+    // --globals-only requires dumpall archive.
+    // Since we don't implement actual archive inspection yet, we always emit
+    // this error when --globals-only is used with a positional file
+    // (which would need to be a real dumpall archive to proceed).
+    if cli.globals_only && !cli.filenames.is_empty() {
+        eprintln!("pg_restore: --globals-only can only be used with pg_dumpall archives");
+        std::process::exit(1);
+    }
+
+    // --exclude-database requires dumpall archive
+    if cli.exclude_database.is_some() && !cli.filenames.is_empty() {
+        eprintln!("pg_restore: --exclude-database can only be used with pg_dumpall archives");
+        std::process::exit(1);
+    }
+
+    // Require either -d or -f or a positional file
+    let has_output = cli.dbname.is_some() || cli.file.is_some() || !cli.filenames.is_empty();
+    if !has_output {
+        eprintln!("pg_restore: one of -d/--dbname and -f/--file must be specified");
+        std::process::exit(1);
+    }
+
+    // Actual restore not yet implemented.
+    eprintln!("pg_restore: not yet implemented");
+    std::process::exit(1);
+}
+
+fn validate_format(fmt: &str) -> bool {
+    matches!(
+        fmt,
+        "plain" | "p" | "custom" | "c" | "directory" | "d" | "tar" | "t"
+    )
 }

--- a/tests/pg_dump/t001_basic.rs
+++ b/tests/pg_dump/t001_basic.rs
@@ -45,10 +45,18 @@ fn pg_dump_version() {
 }
 
 #[test]
-#[ignore]
 /// pg_dump rejects unknown options with nonzero exit.
 /// Source: program_options_handling_ok('pg_dump')
-fn pg_dump_options_handling() {}
+fn pg_dump_options_handling() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("--this-option-does-not-exist")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump with unknown option should exit nonzero"
+    );
+}
 
 #[test]
 /// pg_restore --help exits 0 and prints usage info.
@@ -87,362 +95,1112 @@ fn pg_restore_version() {
 }
 
 #[test]
-#[ignore]
 /// pg_restore rejects unknown options with nonzero exit.
 /// Source: program_options_handling_ok('pg_restore')
-fn pg_restore_options_handling() {}
+fn pg_restore_options_handling() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .arg("--this-option-does-not-exist")
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore with unknown option should exit nonzero"
+    );
+}
 
 #[test]
-#[ignore]
 /// pg_dumpall --help exits 0 and prints usage info.
 /// Source: program_help_ok('pg_dumpall')
-fn pg_dumpall_help() {}
+fn pg_dumpall_help() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .arg("--help")
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(output.status.success(), "pg_dumpall --help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_dumpall"),
+        "help output should mention pg_dumpall"
+    );
+    assert!(stdout.contains("Usage"), "help output should contain Usage");
+}
 
 #[test]
-#[ignore]
 /// pg_dumpall --version exits 0 and prints version string.
 /// Source: program_version_ok('pg_dumpall')
-fn pg_dumpall_version() {}
+fn pg_dumpall_version() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .arg("--version")
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        output.status.success(),
+        "pg_dumpall --version should exit 0"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pg_dumpall (pg_plumbing)"),
+        "version output should contain 'pg_dumpall (pg_plumbing)'"
+    );
+}
 
 #[test]
-#[ignore]
 /// pg_dumpall rejects unknown options with nonzero exit.
 /// Source: program_options_handling_ok('pg_dumpall')
-fn pg_dumpall_options_handling() {}
+fn pg_dumpall_options_handling() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .arg("--this-option-does-not-exist")
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall with unknown option should exit nonzero"
+    );
+}
 
 // ---------------------------------------------------------------
 // Invalid option combinations — pg_dump
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore]
 /// pg_dump errors on too many command-line arguments.
 /// `pg_dump qqq abc` → error: too many command-line arguments (first is "abc")
-fn pg_dump_too_many_args() {}
+fn pg_dump_too_many_args() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["qqq", "abc"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump with too many args should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("too many command-line arguments"),
+        "stderr should mention too many args, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -s/--schema-only and -a/--data-only cannot be used together.
 /// `pg_dump -s -a` → error
-fn pg_dump_schema_only_vs_data_only() {}
+fn pg_dump_schema_only_vs_data_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-s", "-a"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -s -a should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("schema-only") || stderr.contains("data-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -s/--schema-only and --statistics-only cannot be used together.
 /// `pg_dump -s --statistics-only` → error
-fn pg_dump_schema_only_vs_statistics_only() {}
+fn pg_dump_schema_only_vs_statistics_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-s", "--statistics-only"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -s --statistics-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("schema-only") || stderr.contains("statistics-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -a/--data-only and --statistics-only cannot be used together.
 /// `pg_dump -a --statistics-only` → error
-fn pg_dump_data_only_vs_statistics_only() {}
+fn pg_dump_data_only_vs_statistics_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-a", "--statistics-only"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -a --statistics-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("data-only") || stderr.contains("statistics-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --include-foreign-data and -s/--schema-only cannot be used together.
 /// `pg_dump -s --include-foreign-data=xxx` → error
-fn pg_dump_foreign_data_vs_schema_only() {}
+fn pg_dump_foreign_data_vs_schema_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-s", "--include-foreign-data=xxx"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -s --include-foreign-data=xxx should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("foreign-data") || stderr.contains("schema-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --statistics-only and --no-statistics cannot be used together.
 /// `pg_dump --statistics-only --no-statistics` → error
-fn pg_dump_statistics_only_vs_no_statistics() {}
+fn pg_dump_statistics_only_vs_no_statistics() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--statistics-only", "--no-statistics"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --statistics-only --no-statistics should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("statistics"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --include-foreign-data is not supported with parallel backup.
 /// `pg_dump -j2 --include-foreign-data=xxx` → error
-fn pg_dump_foreign_data_vs_parallel() {}
+fn pg_dump_foreign_data_vs_parallel() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-j2", "--include-foreign-data=xxx"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -j2 --include-foreign-data=xxx should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("foreign-data") || stderr.contains("jobs"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -c/--clean and -a/--data-only cannot be used together.
 /// `pg_dump -c -a` → error
-fn pg_dump_clean_vs_data_only() {}
+fn pg_dump_clean_vs_data_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-c", "-a"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -c -a should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("clean") || stderr.contains("data-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --if-exists requires -c/--clean.
 /// `pg_dump --if-exists` → error
-fn pg_dump_if_exists_requires_clean() {}
+fn pg_dump_if_exists_requires_clean() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("--if-exists")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --if-exists should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("if-exists") || stderr.contains("clean"),
+        "stderr should mention --if-exists requires --clean, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Parallel backup only supported by directory format.
 /// `pg_dump -j3` → error (default format is plain, not directory)
-fn pg_dump_parallel_requires_directory() {}
+fn pg_dump_parallel_requires_directory() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("-j3")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -j3 (plain format) should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("directory") || stderr.contains("parallel"),
+        "stderr should mention directory format required, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -j/--jobs must be in range (rejects negative values).
 /// `pg_dump -j -1` → error
-fn pg_dump_jobs_must_be_in_range() {}
+fn pg_dump_jobs_must_be_in_range() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-j", "-1"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -j -1 should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("jobs") || stderr.contains("parallel") || stderr.contains("range"),
+        "stderr should mention invalid jobs, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Invalid output format is rejected.
 /// `pg_dump -F garbage` → error: invalid output format
-fn pg_dump_invalid_format() {}
+fn pg_dump_invalid_format() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-F", "garbage"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -F garbage should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("format") || stderr.contains("garbage"),
+        "stderr should mention invalid format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Unrecognized compression algorithm is rejected.
 /// `pg_dump --compress garbage` → error
-fn pg_dump_invalid_compress_algorithm() {}
+fn pg_dump_invalid_compress_algorithm() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--compress", "garbage"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --compress garbage should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("compress") || stderr.contains("algorithm") || stderr.contains("garbage"),
+        "stderr should mention invalid compression algorithm, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Compression algorithm "none" does not accept a compression level.
 /// `pg_dump --compress none:1` → error
-fn pg_dump_compress_none_with_level() {}
+fn pg_dump_compress_none_with_level() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--compress", "none:1"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --compress none:1 should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("none") || stderr.contains("compress"),
+        "stderr should mention none compression level, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// gzip compression level must be in valid range (1-9).
 /// `pg_dump -Z 15` → error (requires libz)
-fn pg_dump_gzip_level_out_of_range() {}
+fn pg_dump_gzip_level_out_of_range() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-Z", "15"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -Z 15 should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("range") || stderr.contains("compress") || stderr.contains("15"),
+        "stderr should mention out of range, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Compression is not supported by tar archive format.
 /// `pg_dump --compress 1 --format tar` → error (requires libz)
-fn pg_dump_compress_vs_tar() {}
+fn pg_dump_compress_vs_tar() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--compress", "1", "--format", "tar"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --compress 1 --format tar should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("tar") || stderr.contains("compress"),
+        "stderr should mention tar compression not supported, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Non-integer compression option is rejected.
 /// `pg_dump -Z gzip:nonInt` → error (requires libz)
-fn pg_dump_compress_non_integer() {}
+fn pg_dump_compress_non_integer() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["-Z", "gzip:nonInt"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump -Z gzip:nonInt should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("compress") || stderr.contains("invalid") || stderr.contains("nonInt"),
+        "stderr should mention invalid compression level, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --extra-float-digits must be in range.
 /// `pg_dump --extra-float-digits -16` → error
-fn pg_dump_extra_float_digits_range() {}
+fn pg_dump_extra_float_digits_range() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--extra-float-digits", "-16"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --extra-float-digits -16 should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("float") || stderr.contains("range"),
+        "stderr should mention float digits range, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --rows-per-insert must be in range (rejects 0).
 /// `pg_dump --rows-per-insert 0` → error
-fn pg_dump_rows_per_insert_range() {}
+fn pg_dump_rows_per_insert_range() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .args(["--rows-per-insert", "0"])
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --rows-per-insert 0 should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("rows-per-insert") || stderr.contains("range"),
+        "stderr should mention rows-per-insert range, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --on-conflict-do-nothing requires --inserts, --rows-per-insert,
 /// or --column-inserts.
 /// `pg_dump --on-conflict-do-nothing` → error
-fn pg_dump_on_conflict_requires_inserts() {}
+fn pg_dump_on_conflict_requires_inserts() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dump"))
+        .arg("--on-conflict-do-nothing")
+        .output()
+        .expect("failed to run pg_dump");
+    assert!(
+        !output.status.success(),
+        "pg_dump --on-conflict-do-nothing should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("on-conflict") || stderr.contains("inserts"),
+        "stderr should mention on-conflict requires inserts, got: {stderr}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Invalid option combinations — pg_restore
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore]
 /// pg_restore errors on too many command-line arguments.
 /// `pg_restore qqq abc` → error: too many command-line arguments
-fn pg_restore_too_many_args() {}
+fn pg_restore_too_many_args() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["qqq", "abc"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore with too many args should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("too many command-line arguments"),
+        "stderr should mention too many args, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// pg_restore requires one of -d/--dbname and -f/--file.
 /// `pg_restore` (no args) → error
-fn pg_restore_requires_dbname_or_file() {}
+fn pg_restore_requires_dbname_or_file() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore with no args should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dbname")
+            || stderr.contains("file")
+            || stderr.contains("must be specified"),
+        "stderr should mention missing dbname/file, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -a/--data-only and -s/--schema-only cannot be used together.
 /// `pg_restore -s -a -f -` → error
-fn pg_restore_data_only_vs_schema_only() {}
+fn pg_restore_data_only_vs_schema_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-s", "-a", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -s -a -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("data-only") || stderr.contains("schema-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -d/--dbname and -f/--file cannot be used together.
 /// `pg_restore -d xxx -f xxx` → error
-fn pg_restore_dbname_vs_file() {}
+fn pg_restore_dbname_vs_file() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-d", "xxx", "-f", "xxx"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -d xxx -f xxx should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dbname") || stderr.contains("file"),
+        "stderr should mention conflicting -d/-f options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -c/--clean and -a/--data-only cannot be used together.
 /// `pg_restore -c -a -f -` → error
-fn pg_restore_clean_vs_data_only() {}
+fn pg_restore_clean_vs_data_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-c", "-a", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -c -a -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("clean") || stderr.contains("data-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --if-exists requires -c/--clean.
 /// `pg_restore --if-exists -f -` → error
-fn pg_restore_if_exists_requires_clean() {}
+fn pg_restore_if_exists_requires_clean() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--if-exists", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --if-exists -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("if-exists") || stderr.contains("clean"),
+        "stderr should mention --if-exists requires --clean, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -j/--jobs must be in range (rejects negative values).
 /// `pg_restore -j -1 -f -` → error
-fn pg_restore_jobs_must_be_in_range() {}
+fn pg_restore_jobs_must_be_in_range() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-j", "-1", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -j -1 -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("jobs") || stderr.contains("range") || stderr.contains("parallel"),
+        "stderr should mention invalid jobs, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Cannot specify both --single-transaction and multiple jobs.
 /// `pg_restore --single-transaction -j3 -f -` → error
-fn pg_restore_single_transaction_vs_parallel() {}
+fn pg_restore_single_transaction_vs_parallel() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--single-transaction", "-j3", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --single-transaction -j3 -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("single-transaction") || stderr.contains("jobs"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Unrecognized archive format is rejected.
 /// `pg_restore -f - -F garbage` → error
-fn pg_restore_invalid_format() {}
+fn pg_restore_invalid_format() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-f", "-", "-F", "garbage"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -F garbage should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("format") || stderr.contains("garbage"),
+        "stderr should mention invalid format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Empty archive format string is rejected.
 /// `pg_restore -f - -F ""` → error
-fn pg_restore_empty_format() {}
+fn pg_restore_empty_format() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-f", "-", "-F", ""])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -F \"\" should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("format"),
+        "stderr should mention invalid format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -C/--create and -1/--single-transaction cannot be used together.
 /// `pg_restore -C -1 -f -` → error
-fn pg_restore_create_vs_single_transaction() {}
+fn pg_restore_create_vs_single_transaction() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-C", "-1", "-f", "-"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore -C -1 -f - should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("create") || stderr.contains("single-transaction"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --exclude-database and -g/--globals-only cannot be used together.
 /// `pg_restore --exclude-database=foo --globals-only -d xxx` → error
-fn pg_restore_exclude_database_vs_globals_only() {}
+fn pg_restore_exclude_database_vs_globals_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--exclude-database=foo", "--globals-only", "-d", "xxx"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --exclude-database=foo --globals-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("exclude-database") || stderr.contains("globals-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -a/--data-only and -g/--globals-only cannot be used together.
 /// `pg_restore --data-only --globals-only -d xxx` → error
-fn pg_restore_data_only_vs_globals_only() {}
+fn pg_restore_data_only_vs_globals_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--data-only", "--globals-only", "-d", "xxx"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --data-only --globals-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("data-only") || stderr.contains("globals-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -g/--globals-only and -s/--schema-only cannot be used together.
 /// `pg_restore --schema-only --globals-only -d xxx` → error
-fn pg_restore_globals_only_vs_schema_only() {}
+fn pg_restore_globals_only_vs_schema_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--schema-only", "--globals-only", "-d", "xxx"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --schema-only --globals-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("schema-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -g/--globals-only and --statistics-only cannot be used together.
 /// `pg_restore --statistics-only --globals-only -d xxx` → error
-fn pg_restore_globals_only_vs_statistics_only() {}
+fn pg_restore_globals_only_vs_statistics_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--statistics-only", "--globals-only", "-d", "xxx"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --statistics-only --globals-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("statistics-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --exclude-database can only be used with pg_dumpall archives.
 /// `pg_restore --exclude-database=foo -d xxx dumpdir` → error
-fn pg_restore_exclude_database_requires_dumpall_archive() {}
+fn pg_restore_exclude_database_requires_dumpall_archive() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--exclude-database=foo", "-d", "xxx", "dumpdir"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --exclude-database=foo -d xxx dumpdir should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("exclude-database") || stderr.contains("dumpall"),
+        "stderr should mention exclude-database requires dumpall archive, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --globals-only can only be used with pg_dumpall archives.
 /// `pg_restore --globals-only -d xxx dumpdir` → error
-fn pg_restore_globals_only_requires_dumpall_archive() {}
+fn pg_restore_globals_only_requires_dumpall_archive() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--globals-only", "-d", "xxx", "dumpdir"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --globals-only -d xxx dumpdir should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("dumpall"),
+        "stderr should mention globals-only requires dumpall archive, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --globals-only and --no-globals cannot be used together.
 /// `pg_restore --globals-only --no-globals -d xxx dumpdir` → error
-fn pg_restore_globals_only_vs_no_globals() {}
+fn pg_restore_globals_only_vs_no_globals() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["--globals-only", "--no-globals", "-d", "xxx", "dumpdir"])
+        .output()
+        .expect("failed to run pg_restore");
+    assert!(
+        !output.status.success(),
+        "pg_restore --globals-only --no-globals should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("no-globals"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Invalid option combinations — pg_dumpall
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore]
 /// pg_dumpall errors on too many command-line arguments.
 /// `pg_dumpall qqq abc` → error
-fn pg_dumpall_too_many_args() {}
+fn pg_dumpall_too_many_args() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["qqq", "abc"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall with too many args should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("too many command-line arguments"),
+        "stderr should mention too many args, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -c/--clean and -a/--data-only cannot be used together.
 /// `pg_dumpall -c -a` → error
-fn pg_dumpall_clean_vs_data_only() {}
+fn pg_dumpall_clean_vs_data_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-c", "-a"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -c -a should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("clean") || stderr.contains("data-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -g/--globals-only and -r/--roles-only cannot be used together.
 /// `pg_dumpall -g -r` → error
-fn pg_dumpall_globals_only_vs_roles_only() {}
+fn pg_dumpall_globals_only_vs_roles_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-g", "-r"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -g -r should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("roles-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -g/--globals-only and -t/--tablespaces-only cannot be used together.
 /// `pg_dumpall -g -t` → error
-fn pg_dumpall_globals_only_vs_tablespaces_only() {}
+fn pg_dumpall_globals_only_vs_tablespaces_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-g", "-t"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -g -t should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("globals-only") || stderr.contains("tablespaces-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -r/--roles-only and -t/--tablespaces-only cannot be used together.
 /// `pg_dumpall -r -t` → error
-fn pg_dumpall_roles_only_vs_tablespaces_only() {}
+fn pg_dumpall_roles_only_vs_tablespaces_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-r", "-t"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -r -t should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("roles-only") || stderr.contains("tablespaces-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --if-exists requires -c/--clean.
 /// `pg_dumpall --if-exists` → error
-fn pg_dumpall_if_exists_requires_clean() {}
+fn pg_dumpall_if_exists_requires_clean() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .arg("--if-exists")
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --if-exists should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("if-exists") || stderr.contains("clean"),
+        "stderr should mention --if-exists requires --clean, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --exclude-database and -g/--globals-only cannot be used together.
 /// `pg_dumpall --exclude-database=foo --globals-only` → error
-fn pg_dumpall_exclude_database_vs_globals_only() {}
+fn pg_dumpall_exclude_database_vs_globals_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--exclude-database=foo", "--globals-only"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --exclude-database=foo --globals-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("exclude-database") || stderr.contains("globals-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -a/--data-only and --no-data cannot be used together.
 /// `pg_dumpall -a --no-data` → error
-fn pg_dumpall_data_only_vs_no_data() {}
+fn pg_dumpall_data_only_vs_no_data() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-a", "--no-data"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -a --no-data should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("data-only") || stderr.contains("no-data"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// -s/--schema-only and --no-schema cannot be used together.
 /// `pg_dumpall -s --no-schema` → error
-fn pg_dumpall_schema_only_vs_no_schema() {}
+fn pg_dumpall_schema_only_vs_no_schema() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["-s", "--no-schema"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall -s --no-schema should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("schema-only") || stderr.contains("no-schema"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --statistics-only and --no-statistics cannot be used together.
 /// `pg_dumpall --statistics-only --no-statistics` → error
-fn pg_dumpall_statistics_only_vs_no_statistics() {}
+fn pg_dumpall_statistics_only_vs_no_statistics() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--statistics-only", "--no-statistics"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --statistics-only --no-statistics should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("statistics"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --statistics and --no-statistics cannot be used together.
 /// `pg_dumpall --statistics --no-statistics` → error
-fn pg_dumpall_statistics_vs_no_statistics() {}
+fn pg_dumpall_statistics_vs_no_statistics() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--statistics", "--no-statistics"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --statistics --no-statistics should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("statistics"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --statistics and -t/--tablespaces-only cannot be used together.
 /// `pg_dumpall --statistics --tablespaces-only` → error
-fn pg_dumpall_statistics_vs_tablespaces_only() {}
+fn pg_dumpall_statistics_vs_tablespaces_only() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--statistics", "--tablespaces-only"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --statistics --tablespaces-only should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("statistics") || stderr.contains("tablespaces-only"),
+        "stderr should mention conflicting options, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Unrecognized output format is rejected.
 /// `pg_dumpall --format x` → error
-fn pg_dumpall_invalid_format() {}
+fn pg_dumpall_invalid_format() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--format", "x"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --format x should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("format") || stderr.contains("x"),
+        "stderr should mention invalid format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --restrict-key can only be used with --format=plain.
 /// `pg_dumpall --format d --restrict-key=uu -f dumpfile` → error
-fn pg_dumpall_restrict_key_requires_plain() {}
+fn pg_dumpall_restrict_key_requires_plain() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--format", "d", "--restrict-key=uu", "-f", "dumpfile"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --format d --restrict-key=uu should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("restrict-key") || stderr.contains("plain"),
+        "stderr should mention restrict-key requires plain format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// --clean and --globals-only cannot be used together in non-text dump.
 /// `pg_dumpall --format d --globals-only --clean -f dumpfile` → error
-fn pg_dumpall_clean_vs_globals_only_non_text() {}
+fn pg_dumpall_clean_vs_globals_only_non_text() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args([
+            "--format",
+            "d",
+            "--globals-only",
+            "--clean",
+            "-f",
+            "dumpfile",
+        ])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --format d --globals-only --clean should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("clean") || stderr.contains("globals-only") || stderr.contains("plain"),
+        "stderr should mention clean/globals-only conflict in non-plain format, got: {stderr}"
+    );
+}
 
 #[test]
-#[ignore]
 /// Non-plain format requires --file option.
 /// `pg_dumpall --format d` → error
-fn pg_dumpall_non_plain_requires_file() {}
+fn pg_dumpall_non_plain_requires_file() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg_dumpall"))
+        .args(["--format", "d"])
+        .output()
+        .expect("failed to run pg_dumpall");
+    assert!(
+        !output.status.success(),
+        "pg_dumpall --format d (no -f) should exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("file") || stderr.contains("format") || stderr.contains("plain"),
+        "stderr should mention non-plain requires file, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #11

Un-ignores and implements all 59 tests in t001_basic.rs.

- Mutually exclusive flag pairs exit 1 + stderr
- Invalid enum values (format, compress algorithm) exit 1
- Out-of-range integers (jobs, rows-per-insert, compress level) exit 1
- Missing required combos (--if-exists requires --clean, etc.)
- Minimal pg_dumpall stub binary