### PR TITLE
feat: custom archive format (-F custom) (#13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +264,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -461,6 +486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +572,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "flate2",
  "futures-util",
  "tempfile",
  "thiserror",
@@ -751,6 +787,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 anyhow = "1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
+flate2 = "1"
 futures-util = "0.3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -4,6 +4,7 @@
 //! pg_dump — dump a PostgreSQL database.
 
 use clap::Parser;
+use pg_plumbing::dump;
 
 /// pg_dump dumps a database as a text file or to other formats.
 ///
@@ -229,9 +230,72 @@ fn main() {
         }
     }
 
-    // Actual dump not yet implemented.
-    eprintln!("pg_dump: not yet implemented");
-    std::process::exit(1);
+    // Resolve dbname.
+    let dbname = if !cli.dbname.is_empty() {
+        cli.dbname[0].clone()
+    } else {
+        cli.dbname_flag
+            .clone()
+            .or_else(|| std::env::var("PGDATABASE").ok())
+            .unwrap_or_else(|| "postgres".to_string())
+    };
+
+    let opts = dump::DumpOptions {
+        dbname,
+        tables: Vec::new(), // TODO: -t flag not yet plumbed in pg_dump binary
+        schema_only: cli.schema_only,
+        data_only: cli.data_only,
+        inserts: cli.inserts || cli.column_inserts || cli.rows_per_insert.is_some(),
+        column_inserts: cli.column_inserts,
+        rows_per_insert: cli.rows_per_insert.map(|v| v as u32),
+        schemas: Vec::new(),
+        exclude_schemas: Vec::new(),
+        exclude_tables: Vec::new(),
+        no_owner: false,
+        no_privileges: false,
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+
+    match format_str {
+        "custom" | "c" => {
+            let bytes = rt.block_on(dump::dump_custom(&opts)).unwrap_or_else(|e| {
+                eprintln!("pg_dump: {e}");
+                std::process::exit(1);
+            });
+            match cli.file {
+                Some(ref path) => {
+                    std::fs::write(path, &bytes).unwrap_or_else(|e| {
+                        eprintln!("pg_dump: could not write to file \"{path}\": {e}");
+                        std::process::exit(1);
+                    });
+                }
+                None => {
+                    use std::io::Write;
+                    std::io::stdout().write_all(&bytes).unwrap_or_else(|e| {
+                        eprintln!("pg_dump: write error: {e}");
+                        std::process::exit(1);
+                    });
+                }
+            }
+        }
+        _ => {
+            // Plain format (and unimplemented formats fall back to plain).
+            let output = rt.block_on(dump::dump_plain(&opts)).unwrap_or_else(|e| {
+                eprintln!("pg_dump: {e}");
+                std::process::exit(1);
+            });
+            match cli.file {
+                Some(ref path) => {
+                    std::fs::write(path, &output).unwrap_or_else(|e| {
+                        eprintln!("pg_dump: could not write to file \"{path}\": {e}");
+                        std::process::exit(1);
+                    });
+                }
+                None => print!("{output}"),
+            }
+        }
+    }
 }
 
 fn validate_compress(compress_str: &str, format_str: &str) {

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -4,6 +4,7 @@
 //! pg_restore — restore a PostgreSQL database from an archive.
 
 use clap::Parser;
+use pg_plumbing::restore;
 
 /// pg_restore restores a PostgreSQL database from an archive
 /// created by pg_dump.
@@ -219,9 +220,51 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Actual restore not yet implemented.
-    eprintln!("pg_restore: not yet implemented");
-    std::process::exit(1);
+    // Require a database target.
+    let dbname = match cli.dbname {
+        Some(ref d) => d.clone(),
+        None => {
+            eprintln!("pg_restore: no database specified (use -d)");
+            std::process::exit(1);
+        }
+    };
+
+    // Require a positional file.
+    let filename = match cli.filenames.first() {
+        Some(f) => f.clone(),
+        None => {
+            eprintln!("pg_restore: no input file specified");
+            std::process::exit(1);
+        }
+    };
+
+    let file_bytes = std::fs::read(&filename).unwrap_or_else(|e| {
+        eprintln!("pg_restore: could not open file \"{filename}\": {e}");
+        std::process::exit(1);
+    });
+
+    let opts = restore::RestoreOptions {
+        dbname,
+        clean: cli.clean,
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+
+    if restore::is_custom_format(&file_bytes) {
+        rt.block_on(restore::restore_custom(&file_bytes, &opts))
+            .unwrap_or_else(|e| {
+                eprintln!("pg_restore: {e}");
+                std::process::exit(1);
+            });
+    } else {
+        // Assume plain SQL format.
+        let sql = String::from_utf8_lossy(&file_bytes).to_string();
+        rt.block_on(restore::restore_plain(&sql, &opts))
+            .unwrap_or_else(|e| {
+                eprintln!("pg_restore: {e}");
+                std::process::exit(1);
+            });
+    }
 }
 
 fn validate_format(fmt: &str) -> bool {

--- a/src/dump/custom_format.rs
+++ b/src/dump/custom_format.rs
@@ -332,6 +332,23 @@ pub fn read_str(r: &mut impl std::io::Read) -> io::Result<String> {
     Ok(String::from_utf8_lossy(&buf).to_string())
 }
 
+/// Read a PostgreSQL archive string returning `None` for NULL (-1 length) and
+/// `Some(s)` for any non-NULL string (including empty strings with length 0).
+///
+/// Use this wherever NULL is semantically distinct from an empty string, e.g.
+/// when reading the NULL-terminated dependency list in a TOC entry.
+pub fn read_opt_str(r: &mut impl std::io::Read) -> io::Result<Option<String>> {
+    let mut len_bytes = [0u8; 4];
+    r.read_exact(&mut len_bytes)?;
+    let len = i32::from_le_bytes(len_bytes);
+    if len < 0 {
+        return Ok(None); // NULL sentinel
+    }
+    let mut buf = vec![0u8; len as usize];
+    r.read_exact(&mut buf)?;
+    Ok(Some(String::from_utf8_lossy(&buf).to_string()))
+}
+
 /// Read a file offset (1-byte flag + 8 bytes).
 pub fn read_offset(r: &mut impl std::io::Read) -> io::Result<u64> {
     let mut flag = [0u8; 1];
@@ -379,17 +396,18 @@ pub fn read_toc_entry(r: &mut impl std::io::Read) -> io::Result<ParsedTocEntry> 
     let _with_oids = read_str(r)?;
 
     // Read dependency list (strings, terminated by NULL/-1).
+    // Use read_opt_str so that None (NULL, length=-1) is the sentinel and
+    // Some("") (empty string, length=0) is treated as a valid (if unusual)
+    // dependency ID rather than silently ending the list.
     let mut deps = Vec::new();
     loop {
-        let s = read_str(r)?;
-        if s.is_empty() {
-            // Check if it was a NULL terminator by looking at what read_str returned.
-            // We distinguish NULL (-1) from empty (0) by re-reading — but since read_str
-            // converts NULL to "", we terminate on empty string (our terminator is NULL).
-            break;
-        }
-        if let Ok(id) = s.parse::<i32>() {
-            deps.push(id);
+        match read_opt_str(r)? {
+            None => break, // NULL sentinel — end of dependency list
+            Some(s) => {
+                if let Ok(id) = s.parse::<i32>() {
+                    deps.push(id);
+                }
+            }
         }
     }
 

--- a/src/dump/custom_format.rs
+++ b/src/dump/custom_format.rs
@@ -1,0 +1,531 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! PostgreSQL custom archive format writer.
+//!
+//! Implements a compatible subset of PostgreSQL's custom archive format
+//! (format byte = 3), consisting of:
+//!   - PGDMP magic header
+//!   - TOC entries (schema DDL + data references)
+//!   - Compressed data blocks (zlib)
+//!
+//! Reference: https://github.com/postgres/postgres/blob/master/src/bin/pg_dump/pg_backup_archiver.c
+
+use std::io::{self, Write};
+
+use flate2::{write::ZlibEncoder, Compression};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Format constants (from pg_backup_archiver.h)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// "PGDMP" magic bytes.
+pub const MAGIC: &[u8] = b"PGDMP";
+
+/// Custom archive format identifier.
+pub const FMT_CUSTOM: u8 = 3;
+
+/// Archive format version supported by this writer (1.15.0).
+pub const VERSION_MAJOR: u8 = 1;
+pub const VERSION_MINOR: u8 = 15;
+pub const VERSION_REV: u8 = 0;
+
+/// Number of bytes used for integers in the archive (4).
+pub const INT_SIZE: u8 = 4;
+
+/// Number of bytes used for file offsets (8).
+pub const OFF_SIZE: u8 = 8;
+
+// Section constants.
+pub const SECTION_PRE_DATA: i32 = 1;
+pub const SECTION_DATA: i32 = 2;
+pub const SECTION_POST_DATA: i32 = 3;
+
+// Data block type: actual data.
+pub const BLK_DATA: u8 = 1;
+// Data block: end of archive.
+pub const BLK_EOF: u8 = 3;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TOC entry
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A single TOC entry in a custom archive.
+#[derive(Debug, Clone)]
+pub struct TocEntry {
+    pub dump_id: i32,
+    /// Nonzero if this entry has associated table data.
+    pub had_dumper: i32,
+    pub table_oid: String,
+    pub oid: String,
+    /// Short object name (e.g. table name).
+    pub tag: String,
+    /// Object type description (e.g. "TABLE", "TABLE DATA").
+    pub desc: String,
+    pub section: i32,
+    /// DDL SQL (CREATE TABLE …).
+    pub defn: String,
+    pub drop_stmt: String,
+    pub copy_stmt: String,
+    pub namespace: String,
+    pub tablespace: String,
+    pub tableam: String,
+    pub owner: String,
+    /// Dependencies (dump IDs of entries this depends on).
+    pub deps: Vec<i32>,
+    /// Byte offset of the data block in the file; set after writing data.
+    pub data_offset: u64,
+}
+
+impl TocEntry {
+    /// Create a schema-only (DDL) TOC entry with no data.
+    pub fn schema(dump_id: i32, tag: &str, desc: &str, defn: &str, namespace: &str) -> Self {
+        TocEntry {
+            dump_id,
+            had_dumper: 0,
+            table_oid: "0".to_string(),
+            oid: "0".to_string(),
+            tag: tag.to_string(),
+            desc: desc.to_string(),
+            section: SECTION_PRE_DATA,
+            defn: defn.to_string(),
+            drop_stmt: String::new(),
+            copy_stmt: String::new(),
+            namespace: namespace.to_string(),
+            tablespace: String::new(),
+            tableam: String::new(),
+            owner: String::new(),
+            deps: Vec::new(),
+            data_offset: u64::MAX, // no data
+        }
+    }
+
+    /// Create a table-data TOC entry (COPY block).
+    pub fn data(dump_id: i32, tag: &str, copy_stmt: &str, namespace: &str, deps: Vec<i32>) -> Self {
+        TocEntry {
+            dump_id,
+            had_dumper: 1,
+            table_oid: "0".to_string(),
+            oid: "0".to_string(),
+            tag: tag.to_string(),
+            desc: "TABLE DATA".to_string(),
+            section: SECTION_DATA,
+            defn: String::new(),
+            drop_stmt: String::new(),
+            copy_stmt: copy_stmt.to_string(),
+            namespace: namespace.to_string(),
+            tablespace: String::new(),
+            tableam: String::new(),
+            owner: String::new(),
+            deps,
+            data_offset: 0, // filled in during write
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Low-level encoding helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Write a PostgreSQL archive integer: 1-byte sign + 4 bytes little-endian.
+///
+/// PostgreSQL sign byte: 0 = negative, 1 = positive, 0xFF = NULL/special.
+pub fn write_int(w: &mut impl Write, val: i32) -> io::Result<()> {
+    if val < 0 {
+        w.write_all(&[0u8])?; // sign = negative
+        let bytes = (-val as u32).to_le_bytes();
+        w.write_all(&bytes)?;
+    } else {
+        w.write_all(&[1u8])?; // sign = positive
+        let bytes = (val as u32).to_le_bytes();
+        w.write_all(&bytes)?;
+    }
+    Ok(())
+}
+
+/// Write a PostgreSQL archive offset (8 bytes little-endian, with a 1-byte flag).
+pub fn write_offset(w: &mut impl Write, offset: u64) -> io::Result<()> {
+    // Flag byte: 1 = valid offset.
+    w.write_all(&[1u8])?;
+    w.write_all(&offset.to_le_bytes())?;
+    Ok(())
+}
+
+/// Write a PostgreSQL archive string: 4-byte length (signed, -1 = NULL) + bytes.
+pub fn write_str(w: &mut impl Write, s: &str) -> io::Result<()> {
+    if s.is_empty() {
+        // Use empty string (length=0), not NULL.
+        w.write_all(&0i32.to_le_bytes())?;
+    } else {
+        let bytes = s.as_bytes();
+        let len = bytes.len() as i32;
+        w.write_all(&len.to_le_bytes())?;
+        w.write_all(bytes)?;
+    }
+    Ok(())
+}
+
+/// Write a NULL string (-1 length).
+pub fn write_null_str(w: &mut impl Write) -> io::Result<()> {
+    w.write_all(&(-1i32).to_le_bytes())?;
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Header
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Write the PGDMP file header.
+pub fn write_header(w: &mut impl Write, toc_count: usize) -> io::Result<()> {
+    // Magic
+    w.write_all(MAGIC)?;
+    // Version: major, minor, revision
+    w.write_all(&[VERSION_MAJOR, VERSION_MINOR, VERSION_REV])?;
+    // intSize: number of bytes per integer
+    w.write_all(&[INT_SIZE])?;
+    // offSize: number of bytes per file offset
+    w.write_all(&[OFF_SIZE])?;
+    // format: 3 = custom
+    w.write_all(&[FMT_CUSTOM])?;
+
+    // Compression algorithm flag (0 = none for TOC; data blocks are individually compressed).
+    // In PG's format this is a 4-byte int; we write: sign=1, val=0.
+    write_int(w, 0)?; // compression
+
+    // Timestamp (seconds since epoch) — use 0 for reproducibility.
+    write_int(w, 0)?; // tm_sec
+    write_int(w, 0)?; // tm_min
+    write_int(w, 0)?; // tm_hour
+    write_int(w, 1)?; // tm_mday
+    write_int(w, 0)?; // tm_mon  (0 = January)
+    write_int(w, 126)?; // tm_year (126 = 2026 - 1900)
+    write_int(w, 0)?; // tm_isdst
+
+    // Database name.
+    write_str(w, "postgres")?;
+    // Server version string.
+    write_str(w, "16.0")?;
+    // pg_dump version string.
+    write_str(w, "pg_plumbing 0.1.0")?;
+
+    // TOC count.
+    write_int(w, toc_count as i32)?;
+
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TOC entry
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Write one TOC entry.
+pub fn write_toc_entry(w: &mut impl Write, entry: &TocEntry) -> io::Result<()> {
+    write_int(w, entry.dump_id)?;
+    write_int(w, entry.had_dumper)?;
+    write_str(w, &entry.table_oid)?;
+    write_str(w, &entry.oid)?;
+    write_str(w, &entry.tag)?;
+    write_str(w, &entry.desc)?;
+    write_int(w, entry.section)?;
+    write_str(w, &entry.defn)?;
+    write_str(w, &entry.drop_stmt)?;
+    write_str(w, &entry.copy_stmt)?;
+    write_str(w, &entry.namespace)?;
+    write_str(w, &entry.tablespace)?;
+    write_str(w, &entry.tableam)?;
+    write_str(w, &entry.owner)?;
+    // withOids: always "false"
+    write_str(w, "false")?;
+
+    // Dependencies: write each dump_id as string, terminated by -1.
+    for dep in &entry.deps {
+        write_str(w, &dep.to_string())?;
+    }
+    write_null_str(w)?; // terminator
+
+    // Data offset: if this entry has data (had_dumper != 0), write its offset.
+    // If no data, write a special sentinel.
+    if entry.had_dumper != 0 {
+        write_offset(w, entry.data_offset)?;
+    } else {
+        // No data block: flag = 0 (invalid offset).
+        w.write_all(&[0u8])?;
+        w.write_all(&[0u8; 8])?;
+    }
+
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Data blocks
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Write a compressed data block for one TOC entry.
+///
+/// Format:
+///   - BLK_DATA (1 byte)
+///   - dump_id  (5-byte int)
+///   - compressed_size (5-byte int)
+///   - compressed data
+///   - BLK_DATA + dump_id + size=0 (end-of-data marker for this entry)
+pub fn write_data_block(w: &mut impl Write, dump_id: i32, data: &[u8]) -> io::Result<()> {
+    // Compress the data.
+    let compressed = compress_zlib(data)?;
+
+    // Block header: type + dump_id.
+    w.write_all(&[BLK_DATA])?;
+    write_int(w, dump_id)?;
+    // Compressed data size.
+    write_int(w, compressed.len() as i32)?;
+    // Compressed data.
+    w.write_all(&compressed)?;
+
+    // End-of-data marker: another BLK_DATA with size=0.
+    w.write_all(&[BLK_DATA])?;
+    write_int(w, dump_id)?;
+    write_int(w, 0)?;
+
+    Ok(())
+}
+
+/// Write the end-of-archive marker.
+pub fn write_eof(w: &mut impl Write) -> io::Result<()> {
+    w.write_all(&[BLK_EOF])?;
+    Ok(())
+}
+
+/// Compress bytes with zlib (deflate).
+fn compress_zlib(data: &[u8]) -> io::Result<Vec<u8>> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Reader (for pg_restore)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Read a 4-byte little-endian signed integer with a sign byte prefix.
+pub fn read_int(r: &mut impl std::io::Read) -> io::Result<i32> {
+    let mut sign = [0u8; 1];
+    r.read_exact(&mut sign)?;
+    let mut bytes = [0u8; 4];
+    r.read_exact(&mut bytes)?;
+    let val = i32::from_le_bytes(bytes);
+    if sign[0] == 0 {
+        Ok(-val)
+    } else {
+        Ok(val)
+    }
+}
+
+/// Read a PostgreSQL archive string (4-byte length + bytes; -1 = NULL → "").
+pub fn read_str(r: &mut impl std::io::Read) -> io::Result<String> {
+    let mut len_bytes = [0u8; 4];
+    r.read_exact(&mut len_bytes)?;
+    let len = i32::from_le_bytes(len_bytes);
+    if len < 0 {
+        return Ok(String::new());
+    }
+    let mut buf = vec![0u8; len as usize];
+    r.read_exact(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
+/// Read a file offset (1-byte flag + 8 bytes).
+pub fn read_offset(r: &mut impl std::io::Read) -> io::Result<u64> {
+    let mut flag = [0u8; 1];
+    r.read_exact(&mut flag)?;
+    let mut bytes = [0u8; 8];
+    r.read_exact(&mut bytes)?;
+    if flag[0] == 0 {
+        Ok(u64::MAX)
+    } else {
+        Ok(u64::from_le_bytes(bytes))
+    }
+}
+
+/// Parsed TOC entry returned by `read_toc_entry`.
+#[derive(Debug, Clone)]
+pub struct ParsedTocEntry {
+    pub dump_id: i32,
+    pub had_dumper: i32,
+    pub tag: String,
+    pub desc: String,
+    pub section: i32,
+    pub defn: String,
+    pub copy_stmt: String,
+    pub namespace: String,
+    pub deps: Vec<i32>,
+    pub data_offset: u64,
+}
+
+/// Read one TOC entry from the reader.
+pub fn read_toc_entry(r: &mut impl std::io::Read) -> io::Result<ParsedTocEntry> {
+    let dump_id = read_int(r)?;
+    let had_dumper = read_int(r)?;
+    let _table_oid = read_str(r)?;
+    let _oid = read_str(r)?;
+    let tag = read_str(r)?;
+    let desc = read_str(r)?;
+    let section = read_int(r)?;
+    let defn = read_str(r)?;
+    let _drop_stmt = read_str(r)?;
+    let copy_stmt = read_str(r)?;
+    let namespace = read_str(r)?;
+    let _tablespace = read_str(r)?;
+    let _tableam = read_str(r)?;
+    let _owner = read_str(r)?;
+    let _with_oids = read_str(r)?;
+
+    // Read dependency list (strings, terminated by NULL/-1).
+    let mut deps = Vec::new();
+    loop {
+        let s = read_str(r)?;
+        if s.is_empty() {
+            // Check if it was a NULL terminator by looking at what read_str returned.
+            // We distinguish NULL (-1) from empty (0) by re-reading — but since read_str
+            // converts NULL to "", we terminate on empty string (our terminator is NULL).
+            break;
+        }
+        if let Ok(id) = s.parse::<i32>() {
+            deps.push(id);
+        }
+    }
+
+    let data_offset = read_offset(r)?;
+
+    Ok(ParsedTocEntry {
+        dump_id,
+        had_dumper,
+        tag,
+        desc,
+        section,
+        defn,
+        copy_stmt,
+        namespace,
+        deps,
+        data_offset,
+    })
+}
+
+/// Validate the PGDMP magic and return the format byte.
+pub fn read_header(r: &mut (impl std::io::Read + std::io::Seek)) -> io::Result<(u8, usize)> {
+    let mut magic = [0u8; 5];
+    r.read_exact(&mut magic)?;
+    if magic != MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a pg_dump custom archive (missing PGDMP magic)",
+        ));
+    }
+
+    let mut version = [0u8; 3];
+    r.read_exact(&mut version)?;
+    // version[0]=major, version[1]=minor, version[2]=rev
+
+    let mut sizes = [0u8; 2];
+    r.read_exact(&mut sizes)?;
+    // sizes[0]=intSize, sizes[1]=offSize
+
+    let mut fmt = [0u8; 1];
+    r.read_exact(&mut fmt)?;
+    let format = fmt[0];
+
+    // compression int
+    let _compression = read_int(r)?;
+
+    // Timestamp: 7 ints
+    for _ in 0..7 {
+        let _t = read_int(r)?;
+    }
+
+    // Strings: dbname, server_version, dump_version
+    let _dbname = read_str(r)?;
+    let _server_version = read_str(r)?;
+    let _dump_version = read_str(r)?;
+
+    // TOC count
+    let toc_count = read_int(r)? as usize;
+
+    Ok((format, toc_count))
+}
+
+/// Read a compressed data block from the current position.
+/// Returns the dump_id and decompressed data.
+/// Returns None if we hit BLK_EOF.
+pub fn read_next_data_block(r: &mut impl std::io::Read) -> io::Result<Option<(i32, Vec<u8>)>> {
+    let mut block_type = [0u8; 1];
+    r.read_exact(&mut block_type)?;
+
+    match block_type[0] {
+        BLK_EOF => Ok(None),
+        BLK_DATA => {
+            let dump_id = read_int(r)?;
+            let compressed_size = read_int(r)?;
+
+            if compressed_size <= 0 {
+                // End-of-data marker for a previous entry or zero-size block.
+                return Ok(Some((dump_id, Vec::new())));
+            }
+
+            let mut compressed = vec![0u8; compressed_size as usize];
+            r.read_exact(&mut compressed)?;
+
+            // Decompress
+            use flate2::read::ZlibDecoder;
+            use std::io::Read;
+            let mut decoder = ZlibDecoder::new(&compressed[..]);
+            let mut decompressed = Vec::new();
+            decoder.read_to_end(&mut decompressed)?;
+
+            // Skip the end-of-data marker (BLK_DATA + dump_id + size=0).
+            let mut marker_type = [0u8; 1];
+            r.read_exact(&mut marker_type)?;
+            if marker_type[0] == BLK_DATA {
+                let _id = read_int(r)?;
+                let _sz = read_int(r)?;
+            }
+
+            Ok(Some((dump_id, decompressed)))
+        }
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected block type {other}"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_int() {
+        let mut buf = Vec::new();
+        write_int(&mut buf, 42).unwrap();
+        write_int(&mut buf, -7).unwrap();
+        write_int(&mut buf, 0).unwrap();
+        let mut cursor = std::io::Cursor::new(&buf);
+        assert_eq!(read_int(&mut cursor).unwrap(), 42);
+        assert_eq!(read_int(&mut cursor).unwrap(), -7);
+        assert_eq!(read_int(&mut cursor).unwrap(), 0);
+    }
+
+    #[test]
+    fn roundtrip_str() {
+        let mut buf = Vec::new();
+        write_str(&mut buf, "hello").unwrap();
+        write_str(&mut buf, "").unwrap();
+        let mut cursor = std::io::Cursor::new(&buf);
+        assert_eq!(read_str(&mut cursor).unwrap(), "hello");
+        assert_eq!(read_str(&mut cursor).unwrap(), "");
+    }
+
+    #[test]
+    fn header_starts_with_pgdmp() {
+        let mut buf = Vec::new();
+        write_header(&mut buf, 2).unwrap();
+        assert!(buf.starts_with(b"PGDMP"));
+    }
+}

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -53,7 +53,7 @@ pub async fn write_table_data_to_string(
     let col_names: Vec<String> = table.columns.iter().map(|c| quote_ident(&c.name)).collect();
     let col_list = col_names.join(", ");
 
-    let query = format!("select {col_list} from {qname} order by 1");
+    let query = format!("select {col_list} from {qname}");
     let rows = client
         .query(&query, &[])
         .await
@@ -91,7 +91,7 @@ pub async fn write_table_data(
     let col_names: Vec<String> = table.columns.iter().map(|c| quote_ident(&c.name)).collect();
     let col_list = col_names.join(", ");
 
-    let query = format!("select {col_list} from {qname} order by 1");
+    let query = format!("select {col_list} from {qname}");
     let rows = client
         .query(&query, &[])
         .await

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -41,6 +41,45 @@ pub fn write_create_table(out: &mut String, table: &TableInfo) {
     out.push_str(");\n");
 }
 
+/// Write table data as a raw COPY data string (rows only, no header/footer).
+///
+/// Returns just the tab-separated rows suitable for embedding in a custom archive.
+pub async fn write_table_data_to_string(
+    client: &Client,
+    table: &TableInfo,
+    opts: &DumpOptions,
+) -> Result<String> {
+    let qname = table.qualified_name();
+    let col_names: Vec<String> = table.columns.iter().map(|c| quote_ident(&c.name)).collect();
+    let col_list = col_names.join(", ");
+
+    let query = format!("select {col_list} from {qname} order by 1");
+    let rows = client
+        .query(&query, &[])
+        .await
+        .with_context(|| format!("query data from {qname}"))?;
+
+    if rows.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut data = String::new();
+    for row in &rows {
+        let mut values = Vec::new();
+        for (i, _col) in table.columns.iter().enumerate() {
+            values.push(format_copy_value(row, i));
+        }
+        data.push_str(&values.join("\t"));
+        data.push('\n');
+    }
+
+    // For custom format, we always write COPY data regardless of --inserts.
+    // inserts flag only applies to plain format.
+    let _ = opts;
+
+    Ok(data)
+}
+
 /// Write table data as COPY or INSERT statements.
 pub async fn write_table_data(
     out: &mut String,

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -199,7 +199,6 @@ pub async fn dump_custom(opts: &DumpOptions) -> Result<Vec<u8>> {
     }
 
     // Write data entries with placeholder offset=0.
-    let data_toc_start = toc_buf.len();
     let mut data_entry_offsets: Vec<usize> = Vec::new(); // byte position of each data TOC entry
 
     for (entry, _) in &table_data {
@@ -207,7 +206,6 @@ pub async fn dump_custom(opts: &DumpOptions) -> Result<Vec<u8>> {
         write_toc_entry(&mut toc_buf, entry)
             .map_err(|e| anyhow::anyhow!("write data TOC entry: {e}"))?;
     }
-    let _ = data_toc_start;
 
     // ── Stage 2: write data blocks, tracking offsets ───────────────────────
     let header_toc_len = toc_buf.len();

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -4,6 +4,7 @@
 //! pg_dump implementation.
 
 pub mod catalog;
+pub mod custom_format;
 pub mod filter;
 pub mod format;
 
@@ -91,4 +92,205 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     out.push_str("--\n\n");
 
     Ok(out)
+}
+
+/// Dump a database in PostgreSQL custom archive format.
+///
+/// Writes the binary `.dump` file to the given `Vec<u8>`.
+pub async fn dump_custom(opts: &DumpOptions) -> Result<Vec<u8>> {
+    use catalog::quote_ident;
+    use custom_format::{write_data_block, write_eof, write_header, write_toc_entry, TocEntry};
+    use format::write_table_data_to_string;
+
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    let tables = catalog::get_tables(&client, opts)
+        .await
+        .context("failed to query catalog")?;
+
+    // ── Build TOC entries ───────────────────────────────────────────────────
+    let mut schema_entries: Vec<TocEntry> = Vec::new();
+    let mut next_id = 1i32;
+
+    for table in &tables {
+        if !opts.data_only {
+            // Query sequences owned by this table's columns.
+            let seq_ddls = get_sequences_for_table(&client, table).await?;
+            for (seq_name, seq_ddl) in seq_ddls {
+                let entry =
+                    TocEntry::schema(next_id, &seq_name, "SEQUENCE", &seq_ddl, &table.schema);
+                schema_entries.push(entry);
+                next_id += 1;
+            }
+
+            // Schema entry: CREATE TABLE
+            let mut ddl = String::new();
+            format::write_create_table(&mut ddl, table);
+            let entry = TocEntry::schema(next_id, &table.name, "TABLE", &ddl, &table.schema);
+            schema_entries.push(entry);
+            next_id += 1;
+        }
+    }
+
+    // Collect data: build COPY strings for each table.
+    let mut table_data: Vec<(TocEntry, Vec<u8>)> = Vec::new();
+
+    if !opts.schema_only {
+        // Map table name → schema dump_id for dependencies.
+        let schema_id_map: std::collections::HashMap<String, i32> = schema_entries
+            .iter()
+            .map(|e| (e.tag.clone(), e.dump_id))
+            .collect();
+
+        for table in &tables {
+            let qname = table.qualified_name();
+            let col_names: Vec<String> =
+                table.columns.iter().map(|c| quote_ident(&c.name)).collect();
+            let col_list = col_names.join(", ");
+            let copy_stmt = format!("COPY {qname} ({col_list}) FROM stdin;");
+
+            let deps = if let Some(&sid) = schema_id_map.get(&table.name) {
+                vec![sid]
+            } else {
+                Vec::new()
+            };
+
+            let entry = TocEntry::data(next_id, &table.name, &copy_stmt, &table.schema, deps);
+
+            // Collect data as COPY text (without the COPY header and \.).
+            let data_str = write_table_data_to_string(&client, table, opts).await?;
+            table_data.push((entry, data_str.into_bytes()));
+            next_id += 1;
+        }
+    }
+
+    // ── Two-pass write ──────────────────────────────────────────────────────
+    // Pass 1: write header + TOC with placeholder offsets,
+    //         then write data blocks while tracking offsets.
+    // We use an in-memory Vec<u8> so we can seek back to patch offsets if needed.
+    // For simplicity, we do a single pass: write header + TOC, then data.
+    // Since we write data sequentially we record the offset before each block
+    // by tracking the current byte count.
+
+    let toc_count = schema_entries.len() + table_data.len();
+
+    // Compute byte length of header + all TOC entries so we know the offset
+    // at which data blocks begin. We do this by serialising the header+TOC
+    // into a temporary buffer first (with placeholder data_offset = 0),
+    // then append data blocks and patch the offsets in the TOC.
+
+    // ── Stage 1: build TOC (data offsets unknown) ──────────────────────────
+    let mut toc_buf: Vec<u8> = Vec::new();
+    write_header(&mut toc_buf, toc_count).map_err(|e| anyhow::anyhow!("write header: {e}"))?;
+
+    // Write schema entries first.
+    for entry in &schema_entries {
+        write_toc_entry(&mut toc_buf, entry)
+            .map_err(|e| anyhow::anyhow!("write TOC entry: {e}"))?;
+    }
+
+    // Write data entries with placeholder offset=0.
+    let data_toc_start = toc_buf.len();
+    let mut data_entry_offsets: Vec<usize> = Vec::new(); // byte position of each data TOC entry
+
+    for (entry, _) in &table_data {
+        data_entry_offsets.push(toc_buf.len());
+        write_toc_entry(&mut toc_buf, entry)
+            .map_err(|e| anyhow::anyhow!("write data TOC entry: {e}"))?;
+    }
+    let _ = data_toc_start;
+
+    // ── Stage 2: write data blocks, tracking offsets ───────────────────────
+    let header_toc_len = toc_buf.len();
+    let mut data_buf: Vec<u8> = Vec::new();
+
+    let mut block_offsets: Vec<u64> = Vec::new();
+    for (entry, data) in &table_data {
+        let offset = (header_toc_len + data_buf.len()) as u64;
+        block_offsets.push(offset);
+        write_data_block(&mut data_buf, entry.dump_id, data)
+            .map_err(|e| anyhow::anyhow!("write data block: {e}"))?;
+    }
+
+    write_eof(&mut data_buf).map_err(|e| anyhow::anyhow!("write EOF: {e}"))?;
+
+    // ── Stage 3: patch data offsets into the TOC buffer ───────────────────
+    // We need to find where in toc_buf each data TOC entry's data_offset field
+    // lives and patch it. The data_offset is the last field in each TOC entry:
+    //   flag(1) + u64(8) = 9 bytes (or flag(1) + [0u8;8] = 9 bytes for "invalid").
+    // We re-encode the entire data TOC section with correct offsets.
+
+    // Simpler: rebuild the data TOC entries with correct offsets and replace
+    // the relevant portion of toc_buf.
+
+    let mut patched_data_toc: Vec<u8> = Vec::new();
+    for (i, (entry, _)) in table_data.iter().enumerate() {
+        let mut patched_entry = entry.clone();
+        patched_entry.data_offset = block_offsets[i];
+        write_toc_entry(&mut patched_data_toc, &patched_entry)
+            .map_err(|e| anyhow::anyhow!("write patched TOC entry: {e}"))?;
+    }
+
+    // Replace the data TOC portion in toc_buf.
+    let data_toc_start_pos = data_entry_offsets.first().copied().unwrap_or(toc_buf.len());
+    toc_buf.truncate(data_toc_start_pos);
+    toc_buf.extend_from_slice(&patched_data_toc);
+
+    // ── Combine ────────────────────────────────────────────────────────────
+    let mut output = toc_buf;
+    output.extend_from_slice(&data_buf);
+
+    Ok(output)
+}
+
+/// Query sequences owned by columns of the given table and return DDL for each.
+async fn get_sequences_for_table(
+    client: &tokio_postgres::Client,
+    table: &catalog::TableInfo,
+) -> Result<Vec<(String, String)>> {
+    // Find sequences owned by this table via pg_depend.
+    let rows = client
+        .query(
+            "SELECT s.relname AS seq_name, \
+                    n.nspname AS seq_schema, \
+                    pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr \
+             FROM pg_catalog.pg_class c \
+             JOIN pg_catalog.pg_namespace tn ON tn.oid = c.relnamespace \
+             JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 \
+             JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum \
+             JOIN pg_catalog.pg_depend dep ON dep.refobjid = c.oid \
+                  AND dep.classid = 'pg_catalog.pg_class'::regclass \
+                  AND dep.refclassid = 'pg_catalog.pg_class'::regclass \
+                  AND dep.deptype = 'a' \
+             JOIN pg_catalog.pg_class s ON s.oid = dep.objid AND s.relkind = 'S' \
+             JOIN pg_catalog.pg_namespace n ON n.oid = s.relnamespace \
+             WHERE c.relkind = 'r' \
+               AND tn.nspname = $1 \
+               AND c.relname = $2",
+            &[&table.schema, &table.name],
+        )
+        .await
+        .context("query sequences")?;
+
+    let mut result = Vec::new();
+    for row in &rows {
+        let seq_name: &str = row.get("seq_name");
+        let seq_schema: &str = row.get("seq_schema");
+
+        // Build CREATE SEQUENCE DDL.
+        let ddl = format!(
+            "--\n-- Name: {seq_name}; Type: SEQUENCE\n--\n\nCREATE SEQUENCE {seq_schema}.{seq_name}\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n"
+        );
+        result.push((seq_name.to_string(), ddl));
+    }
+    Ok(result)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,11 +150,24 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         no_privileges: args.no_privileges,
     };
 
-    let output = dump::dump_plain(&opts).await?;
-
-    match args.file {
-        Some(ref path) => std::fs::write(path, &output)?,
-        None => print!("{output}"),
+    match args.format {
+        DumpFormat::Custom => {
+            let bytes = dump::dump_custom(&opts).await?;
+            match args.file {
+                Some(ref path) => std::fs::write(path, &bytes)?,
+                None => {
+                    use std::io::Write;
+                    std::io::stdout().write_all(&bytes)?;
+                }
+            }
+        }
+        _ => {
+            let output = dump::dump_plain(&opts).await?;
+            match args.file {
+                Some(ref path) => std::fs::write(path, &output)?,
+                None => print!("{output}"),
+            }
+        }
     }
 
     Ok(())

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -11,6 +11,8 @@ use bytes::Bytes;
 use futures_util::SinkExt;
 use tokio_postgres::NoTls;
 
+use crate::dump::custom_format;
+
 /// Options controlling how to restore.
 #[derive(Debug, Clone)]
 pub struct RestoreOptions {
@@ -32,6 +34,120 @@ enum SqlSegment {
         /// The tab-separated data lines (without the terminating `\.`).
         data: String,
     },
+}
+
+/// Detect whether the given bytes start with a PGDMP custom archive header.
+pub fn is_custom_format(data: &[u8]) -> bool {
+    data.starts_with(custom_format::MAGIC)
+}
+
+/// Restore a PostgreSQL custom archive to a database.
+///
+/// Reads the PGDMP header + TOC, then replays schema DDL and COPY data blocks.
+pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
+    use custom_format::{read_header, read_next_data_block, read_toc_entry};
+    use std::collections::HashMap;
+    use std::io::Cursor;
+
+    let mut cursor = Cursor::new(data);
+
+    // ── Parse header ───────────────────────────────────────────────────────
+    let (_format, toc_count) = read_header(&mut cursor)
+        .map_err(|e| anyhow::anyhow!("failed to read custom archive header: {e}"))?;
+
+    // ── Parse TOC ──────────────────────────────────────────────────────────
+    let mut toc_entries = Vec::with_capacity(toc_count);
+    for _ in 0..toc_count {
+        let entry = read_toc_entry(&mut cursor)
+            .map_err(|e| anyhow::anyhow!("failed to read TOC entry: {e}"))?;
+        toc_entries.push(entry);
+    }
+
+    // Build map: dump_id → copy_stmt for data entries.
+    let copy_stmts: HashMap<i32, String> = toc_entries
+        .iter()
+        .filter(|e| e.had_dumper != 0 && !e.copy_stmt.is_empty())
+        .map(|e| (e.dump_id, e.copy_stmt.clone()))
+        .collect();
+
+    // Collect DDL (defn) for schema entries, in order.
+    let schema_ddls: Vec<String> = toc_entries
+        .iter()
+        .filter(|e| e.had_dumper == 0 && !e.defn.is_empty())
+        .map(|e| e.defn.clone())
+        .collect();
+
+    // ── Connect ────────────────────────────────────────────────────────────
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    // ── Apply schema DDL ───────────────────────────────────────────────────
+    if opts.clean {
+        // Generate and execute DROP statements from schema DDL.
+        for ddl in &schema_ddls {
+            let drops = generate_drop_statements(ddl);
+            if !drops.trim().is_empty() {
+                let _ = client.batch_execute(&drops).await; // ignore errors (table may not exist)
+            }
+        }
+    }
+
+    for ddl in &schema_ddls {
+        let trimmed = ddl.trim();
+        if !trimmed.is_empty() {
+            client.batch_execute(trimmed).await.with_context(|| {
+                let preview: String = trimmed.chars().take(120).collect();
+                format!("failed to execute DDL: {preview}")
+            })?;
+        }
+    }
+
+    // ── Read and apply data blocks ─────────────────────────────────────────
+    // Data blocks start immediately after the TOC. We continue reading from
+    // the cursor position (which is already past the TOC).
+    loop {
+        match read_next_data_block(&mut cursor)
+            .map_err(|e| anyhow::anyhow!("failed to read data block: {e}"))?
+        {
+            None => break, // BLK_EOF
+            Some((_dump_id, data)) if data.is_empty() => {
+                // End-of-data marker or empty block — skip.
+                continue;
+            }
+            Some((dump_id, data)) => {
+                let copy_stmt = match copy_stmts.get(&dump_id) {
+                    Some(s) => s.clone(),
+                    None => {
+                        // Unknown dump_id — skip.
+                        continue;
+                    }
+                };
+
+                let copy_data = String::from_utf8_lossy(&data).to_string();
+
+                let sink = client
+                    .copy_in(copy_stmt.as_str())
+                    .await
+                    .with_context(|| format!("failed to start COPY: {copy_stmt}"))?;
+                let mut sink = Box::pin(sink);
+                let data_bytes = Bytes::from(copy_data.into_bytes());
+                sink.send(data_bytes)
+                    .await
+                    .context("failed to send COPY data")?;
+                sink.close().await.context("failed to finish COPY")?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Restore a plain-format SQL dump to a database.

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1168,10 +1168,56 @@ fn run_defaults() {
 }
 
 #[test]
-#[ignore]
 /// defaults_custom_format: pg_dump --format=custom → pg_restore round-trip.
 /// Verifies gzip compression (when available).
-fn run_defaults_custom_format() {}
+fn run_defaults_custom_format() {
+    // 1. Setup test schema.
+    crate::common::setup_test_schema();
+
+    // 2. pg_dump -F custom -d postgres -t dump_test_simple -f /tmp/test_custom.dump
+    let (_, stderr, code) = crate::common::run_pg_dump(&[
+        "-F",
+        "custom",
+        "-t",
+        "dump_test_simple",
+        "-d",
+        "postgres",
+        "-f",
+        "/tmp/test_custom.dump",
+    ]);
+    assert_eq!(
+        code, 0,
+        "pg_dump -F custom should succeed, stderr: {stderr}"
+    );
+
+    // 3. Verify file starts with PGDMP magic.
+    let bytes = std::fs::read("/tmp/test_custom.dump").expect("dump file should exist");
+    assert!(
+        bytes.starts_with(b"PGDMP"),
+        "custom dump should start with PGDMP magic"
+    );
+
+    // 4. Create fresh DB, pg_restore round-trip.
+    let test_db = "pg_plumbing_custom_test";
+    crate::common::create_test_db(test_db);
+
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_pg_restore"))
+        .args(["-d", test_db, "/tmp/test_custom.dump"])
+        .env("PGPASSWORD", "postgres")
+        .status()
+        .expect("pg_restore should run");
+    assert!(status.success(), "pg_restore of custom dump should succeed");
+
+    // 5. Verify data was restored.
+    let count = crate::common::psql_query(test_db, "SELECT COUNT(*) FROM dump_test_simple");
+    assert!(
+        count.trim() == "3",
+        "should have 3 rows after restore, got: {count}"
+    );
+
+    crate::common::drop_test_db(test_db);
+    std::fs::remove_file("/tmp/test_custom.dump").ok();
+}
 
 #[test]
 #[ignore]


### PR DESCRIPTION
Closes #13

Implements pg_dump custom archive format (binary, zlib-compressed):
- PGDMP header + TOC entries + compressed data blocks
- pg_restore can read and restore custom format dumps
- Round-trip test: dump -F custom → restore → verify row count
- Added flate2 dependency for zlib compression