### PR TITLE
feat: directory format dump/restore (-F directory) (#14)

### DIFF
--- a/src/dump/directory_format.rs
+++ b/src/dump/directory_format.rs
@@ -1,0 +1,182 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! Directory format dump (`pg_dump -F directory`).
+//!
+//! Creates a directory containing:
+//!   - `toc.dat` — text TOC listing schema DDL and data file references
+//!   - `<N>.dat`  — one plain COPY-format file per table with data
+
+use anyhow::{bail, Context, Result};
+use tokio_postgres::{Client, NoTls};
+
+use super::catalog;
+use super::format;
+use super::DumpOptions;
+
+/// Dump a database in directory format.
+///
+/// Creates `output_dir` (errors if it already exists and is non-empty),
+/// writes `toc.dat` and one `<N>.dat` per table.
+pub async fn dump_directory(opts: &DumpOptions, output_dir: &str) -> Result<()> {
+    // Create the output directory; fail if it already exists and is non-empty.
+    let dir_path = std::path::Path::new(output_dir);
+    if dir_path.exists() {
+        let entries: Vec<_> = std::fs::read_dir(dir_path)
+            .context("failed to read output directory")?
+            .collect();
+        if !entries.is_empty() {
+            bail!("directory \"{}\" exists and is not empty", output_dir);
+        }
+    } else {
+        std::fs::create_dir_all(dir_path)
+            .with_context(|| format!("failed to create directory \"{}\"", output_dir))?;
+    }
+
+    // Connect to the database.
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    let tables = catalog::get_tables(&client, opts)
+        .await
+        .context("failed to query catalog")?;
+
+    // Build the TOC and per-table data files.
+    let mut toc = String::new();
+
+    toc.push_str("; pg_plumbing directory format TOC\n");
+    toc.push_str(&format!("; dbname: {}\n", opts.dbname));
+    toc.push_str(";\n");
+
+    // Schema section.
+    if !opts.data_only {
+        for table in &tables {
+            // Dump any sequences that this table's columns depend on first.
+            let sequences = get_table_sequences(&client, table).await?;
+            for (seq_schema, seq_name, seq_ddl) in &sequences {
+                let seq_key = format!("{seq_schema}.{seq_name}");
+                let seq_file = format!("{seq_name}.seq.ddl");
+                let seq_path = dir_path.join(&seq_file);
+                std::fs::write(&seq_path, seq_ddl)
+                    .with_context(|| format!("failed to write {seq_file}"))?;
+                toc.push_str(&format!("SEQUENCE {seq_key} {seq_file}\n"));
+            }
+
+            let mut ddl = String::new();
+            format::write_create_table(&mut ddl, table);
+            let ddl_file = format!("{}.ddl", table.name);
+            let ddl_path = dir_path.join(&ddl_file);
+            std::fs::write(&ddl_path, &ddl)
+                .with_context(|| format!("failed to write {ddl_file}"))?;
+            toc.push_str(&format!("TABLE {} {ddl_file}\n", table.qualified_name()));
+        }
+    }
+
+    // Data section.
+    if !opts.schema_only {
+        for (idx, table) in tables.iter().enumerate() {
+            let dat_file = format!("{}.dat", idx + 1);
+            let dat_path = dir_path.join(&dat_file);
+
+            let mut data_buf = String::new();
+            format::write_table_data(&mut data_buf, &client, table, opts).await?;
+
+            // Only write data file if there is actual data.
+            if !data_buf.is_empty() {
+                std::fs::write(&dat_path, &data_buf)
+                    .with_context(|| format!("failed to write {dat_file}"))?;
+                toc.push_str(&format!("DATA {} {dat_file}\n", table.qualified_name()));
+            }
+        }
+    }
+
+    // Write toc.dat.
+    let toc_path = dir_path.join("toc.dat");
+    std::fs::write(&toc_path, &toc).context("failed to write toc.dat")?;
+
+    Ok(())
+}
+
+/// Return sequences that any column of this table depends on (via DEFAULT nextval).
+///
+/// Returns a list of (schema, name, create_ddl) tuples.
+async fn get_table_sequences(
+    client: &Client,
+    table: &catalog::TableInfo,
+) -> Result<Vec<(String, String, String)>> {
+    let rows = client
+        .query(
+            "SELECT DISTINCT n.nspname AS seq_schema, s.relname AS seq_name
+             FROM pg_catalog.pg_class t
+             JOIN pg_catalog.pg_namespace tn ON tn.oid = t.relnamespace
+             JOIN pg_catalog.pg_depend d ON d.refobjid = t.oid
+             JOIN pg_catalog.pg_class s ON s.oid = d.objid
+             JOIN pg_catalog.pg_namespace n ON n.oid = s.relnamespace
+             WHERE t.relkind = 'r'
+               AND s.relkind = 'S'
+               AND tn.nspname = $1
+               AND t.relname = $2
+               AND d.deptype = 'a'",
+            &[&table.schema, &table.name],
+        )
+        .await
+        .context("failed to query sequences for table")?;
+
+    let mut result = Vec::new();
+    for row in &rows {
+        let seq_schema: &str = row.get("seq_schema");
+        let seq_name: &str = row.get("seq_name");
+        let ddl = get_sequence_ddl(client, seq_schema, seq_name).await?;
+        result.push((seq_schema.to_string(), seq_name.to_string(), ddl));
+    }
+    Ok(result)
+}
+
+/// Generate CREATE SEQUENCE DDL for a sequence.
+async fn get_sequence_ddl(client: &Client, schema: &str, name: &str) -> Result<String> {
+    let rows = client
+        .query(
+            "SELECT s.start_value, s.minimum_value, s.maximum_value,
+                    s.increment, s.cycle_option
+             FROM information_schema.sequences s
+             WHERE s.sequence_schema = $1 AND s.sequence_name = $2",
+            &[&schema, &name],
+        )
+        .await
+        .context("failed to query sequence definition")?;
+
+    if let Some(row) = rows.first() {
+        let start: &str = row.get("start_value");
+        let min: &str = row.get("minimum_value");
+        let max: &str = row.get("maximum_value");
+        let inc: &str = row.get("increment");
+        let cycle: &str = row.get("cycle_option");
+
+        let qname = format!(
+            "{}.{}",
+            catalog::quote_ident(schema),
+            catalog::quote_ident(name)
+        );
+        let cycle_clause = if cycle == "YES" { " CYCLE" } else { "" };
+
+        Ok(format!(
+            "CREATE SEQUENCE {qname}\n    INCREMENT BY {inc}\n    MINVALUE {min}\n    MAXVALUE {max}\n    START WITH {start}{cycle_clause};\n"
+        ))
+    } else {
+        // Fallback: minimal sequence definition.
+        let qname = format!(
+            "{}.{}",
+            catalog::quote_ident(schema),
+            catalog::quote_ident(name)
+        );
+        Ok(format!("CREATE SEQUENCE {qname};\n"))
+    }
+}

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -4,6 +4,7 @@
 //! pg_dump implementation.
 
 pub mod catalog;
+pub mod directory_format;
 pub mod filter;
 pub mod format;
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -4,11 +4,8 @@
 //! pg_dump implementation.
 
 pub mod catalog;
-<<<<<<< HEAD
-pub mod directory_format;
-=======
 pub mod custom_format;
->>>>>>> origin/main
+pub mod directory_format;
 pub mod filter;
 pub mod format;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,14 +151,6 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
     };
 
     match args.format {
-<<<<<<< HEAD
-        DumpFormat::Directory => {
-            let output_dir = args
-                .file
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("directory format requires -f/--file"))?;
-            dump::directory_format::dump_directory(&opts, output_dir).await?;
-=======
         DumpFormat::Custom => {
             let bytes = dump::dump_custom(&opts).await?;
             match args.file {
@@ -168,7 +160,13 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
                     std::io::stdout().write_all(&bytes)?;
                 }
             }
->>>>>>> origin/main
+        }
+        DumpFormat::Directory => {
+            let output_dir = args
+                .file
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("directory format requires -f/--file"))?;
+            dump::directory_format::dump_directory(&opts, output_dir).await?;
         }
         _ => {
             let output = dump::dump_plain(&opts).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,11 +150,21 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         no_privileges: args.no_privileges,
     };
 
-    let output = dump::dump_plain(&opts).await?;
-
-    match args.file {
-        Some(ref path) => std::fs::write(path, &output)?,
-        None => print!("{output}"),
+    match args.format {
+        DumpFormat::Directory => {
+            let output_dir = args
+                .file
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("directory format requires -f/--file"))?;
+            dump::directory_format::dump_directory(&opts, output_dir).await?;
+        }
+        _ => {
+            let output = dump::dump_plain(&opts).await?;
+            match args.file {
+                Some(ref path) => std::fs::write(path, &output)?,
+                None => print!("{output}"),
+            }
+        }
     }
 
     Ok(())
@@ -171,6 +181,16 @@ async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
         None => bail!("pg_restore: no input file specified"),
     };
 
+    let opts = restore::RestoreOptions {
+        dbname,
+        clean: args.clean,
+    };
+
+    // If the path is a directory, use directory-format restore.
+    if std::path::Path::new(&filename).is_dir() {
+        return restore::restore_directory(&filename, &opts).await;
+    }
+
     let sql = if filename == "-" {
         use std::io::Read;
         let mut buf = String::new();
@@ -178,11 +198,6 @@ async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
         buf
     } else {
         std::fs::read_to_string(&filename)?
-    };
-
-    let opts = restore::RestoreOptions {
-        dbname,
-        clean: args.clean,
     };
 
     restore::restore_plain(&sql, &opts).await

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -36,7 +36,21 @@ enum SqlSegment {
     },
 }
 
-<<<<<<< HEAD
+/// Safely join a filename from an archive to a base directory.
+///
+/// Rejects absolute paths, path separators, and leading dots to prevent
+/// path traversal attacks (zip-slip style).
+fn safe_join(base: &std::path::Path, filename: &str) -> Result<std::path::PathBuf> {
+    if filename.is_empty()
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.starts_with('.')
+    {
+        anyhow::bail!("unsafe filename in archive: {:?}", filename);
+    }
+    Ok(base.join(filename))
+}
+
 /// Restore a directory-format dump to a database.
 ///
 /// Reads `toc.dat` from `input_dir`, executes schema DDL files listed
@@ -63,7 +77,7 @@ pub async fn restore_directory(input_dir: &str, opts: &RestoreOptions) -> Result
         }
         let mut parts = line.splitn(3, ' ');
         let kind = parts.next().unwrap_or("");
-        let _qname = parts.next().unwrap_or("").to_string();
+        let qname = parts.next().unwrap_or("").to_string();
         let file = parts.next().unwrap_or("").to_string();
 
         match kind {
@@ -71,14 +85,78 @@ pub async fn restore_directory(input_dir: &str, opts: &RestoreOptions) -> Result
                 schema_files.push(file);
             }
             "DATA" => {
-                data_entries.push((_qname, file));
+                data_entries.push((qname, file));
             }
             _ => {} // ignore unknown entries
         }
     }
 
     // Connect to the database.
-=======
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    // Execute schema DDL files.
+    for ddl_file in &schema_files {
+        let ddl_path = safe_join(dir_path, ddl_file)?;
+        let ddl = std::fs::read_to_string(&ddl_path)
+            .with_context(|| format!("failed to read DDL file {ddl_file}"))?;
+        let trimmed = ddl.trim();
+        if !trimmed.is_empty() {
+            client
+                .batch_execute(trimmed)
+                .await
+                .with_context(|| format!("failed to execute DDL from {ddl_file}"))?;
+        }
+    }
+
+    // Restore data files via COPY.
+    for (qname, dat_file) in &data_entries {
+        let dat_path = safe_join(dir_path, dat_file)?;
+        let dat = std::fs::read_to_string(&dat_path)
+            .with_context(|| format!("failed to read data file {dat_file}"))?;
+
+        // Parse the COPY block from the .dat file.
+        let segments = parse_sql_segments(&dat);
+        for segment in &segments {
+            match segment {
+                SqlSegment::Statements(stmts) => {
+                    let trimmed = stmts.trim();
+                    if !trimmed.is_empty() {
+                        client
+                            .batch_execute(trimmed)
+                            .await
+                            .with_context(|| format!("failed to execute SQL from {dat_file}"))?;
+                    }
+                }
+                SqlSegment::CopyBlock { header, data } => {
+                    let sink = client
+                        .copy_in(header.as_str())
+                        .await
+                        .with_context(|| format!("failed to start COPY for {qname}"))?;
+                    let mut sink = Box::pin(sink);
+                    let data_bytes = bytes::Bytes::from(data.clone());
+                    futures_util::SinkExt::send(&mut sink, data_bytes)
+                        .await
+                        .context("failed to send COPY data")?;
+                    futures_util::SinkExt::close(&mut sink)
+                        .await
+                        .context("failed to finish COPY")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Detect whether the given bytes start with a PGDMP custom archive header.
 pub fn is_custom_format(data: &[u8]) -> bool {
     data.starts_with(custom_format::MAGIC)
@@ -121,7 +199,6 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
         .collect();
 
     // ── Connect ────────────────────────────────────────────────────────────
->>>>>>> origin/main
     let conninfo = crate::build_conninfo(&opts.dbname);
     let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
         .await
@@ -133,55 +210,6 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
         }
     });
 
-<<<<<<< HEAD
-    // Execute schema DDL files.
-    for ddl_file in &schema_files {
-        let ddl_path = dir_path.join(ddl_file);
-        let ddl = std::fs::read_to_string(&ddl_path)
-            .with_context(|| format!("failed to read DDL file {ddl_file}"))?;
-        let trimmed = ddl.trim();
-        if !trimmed.is_empty() {
-            client
-                .batch_execute(trimmed)
-                .await
-                .with_context(|| format!("failed to execute DDL from {ddl_file}"))?;
-        }
-    }
-
-    // Restore data files via COPY.
-    for (qname, dat_file) in &data_entries {
-        let dat_path = dir_path.join(dat_file);
-        let dat = std::fs::read_to_string(&dat_path)
-            .with_context(|| format!("failed to read data file {dat_file}"))?;
-
-        // Parse the COPY block from the .dat file.
-        let segments = parse_sql_segments(&dat);
-        for segment in &segments {
-            match segment {
-                SqlSegment::Statements(stmts) => {
-                    let trimmed = stmts.trim();
-                    if !trimmed.is_empty() {
-                        client
-                            .batch_execute(trimmed)
-                            .await
-                            .with_context(|| format!("failed to execute SQL from {dat_file}"))?;
-                    }
-                }
-                SqlSegment::CopyBlock { header, data } => {
-                    let sink = client
-                        .copy_in(header.as_str())
-                        .await
-                        .with_context(|| format!("failed to start COPY for {qname}"))?;
-                    let mut sink = Box::pin(sink);
-                    let data_bytes = bytes::Bytes::from(data.clone());
-                    futures_util::SinkExt::send(&mut sink, data_bytes)
-                        .await
-                        .context("failed to send COPY data")?;
-                    futures_util::SinkExt::close(&mut sink)
-                        .await
-                        .context("failed to finish COPY")?;
-                }
-=======
     // ── Apply schema DDL ───────────────────────────────────────────────────
     if opts.clean {
         // Generate and execute DROP statements from schema DDL.
@@ -236,7 +264,6 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
                     .await
                     .context("failed to send COPY data")?;
                 sink.close().await.context("failed to finish COPY")?;
->>>>>>> origin/main
             }
         }
     }

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -34,6 +34,112 @@ enum SqlSegment {
     },
 }
 
+/// Restore a directory-format dump to a database.
+///
+/// Reads `toc.dat` from `input_dir`, executes schema DDL files listed
+/// therein, then streams each data `.dat` file via COPY.
+pub async fn restore_directory(input_dir: &str, opts: &RestoreOptions) -> Result<()> {
+    let dir_path = std::path::Path::new(input_dir);
+    if !dir_path.is_dir() {
+        anyhow::bail!("\"{}\" is not a directory", input_dir);
+    }
+
+    let toc_path = dir_path.join("toc.dat");
+    let toc = std::fs::read_to_string(&toc_path)
+        .with_context(|| format!("failed to read toc.dat in \"{}\"", input_dir))?;
+
+    // Parse TOC lines into (kind, qualified_name, filename) entries.
+    // Format: `TABLE <qname> <file>` or `DATA <qname> <file>` (comments start with `;`)
+    let mut schema_files: Vec<String> = Vec::new();
+    let mut data_entries: Vec<(String, String)> = Vec::new(); // (qname, file)
+
+    for line in toc.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(';') {
+            continue;
+        }
+        let mut parts = line.splitn(3, ' ');
+        let kind = parts.next().unwrap_or("");
+        let _qname = parts.next().unwrap_or("").to_string();
+        let file = parts.next().unwrap_or("").to_string();
+
+        match kind {
+            "SEQUENCE" | "TABLE" => {
+                schema_files.push(file);
+            }
+            "DATA" => {
+                data_entries.push((_qname, file));
+            }
+            _ => {} // ignore unknown entries
+        }
+    }
+
+    // Connect to the database.
+    let conninfo = crate::build_conninfo(&opts.dbname);
+    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+        .await
+        .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    // Execute schema DDL files.
+    for ddl_file in &schema_files {
+        let ddl_path = dir_path.join(ddl_file);
+        let ddl = std::fs::read_to_string(&ddl_path)
+            .with_context(|| format!("failed to read DDL file {ddl_file}"))?;
+        let trimmed = ddl.trim();
+        if !trimmed.is_empty() {
+            client
+                .batch_execute(trimmed)
+                .await
+                .with_context(|| format!("failed to execute DDL from {ddl_file}"))?;
+        }
+    }
+
+    // Restore data files via COPY.
+    for (qname, dat_file) in &data_entries {
+        let dat_path = dir_path.join(dat_file);
+        let dat = std::fs::read_to_string(&dat_path)
+            .with_context(|| format!("failed to read data file {dat_file}"))?;
+
+        // Parse the COPY block from the .dat file.
+        let segments = parse_sql_segments(&dat);
+        for segment in &segments {
+            match segment {
+                SqlSegment::Statements(stmts) => {
+                    let trimmed = stmts.trim();
+                    if !trimmed.is_empty() {
+                        client
+                            .batch_execute(trimmed)
+                            .await
+                            .with_context(|| format!("failed to execute SQL from {dat_file}"))?;
+                    }
+                }
+                SqlSegment::CopyBlock { header, data } => {
+                    let sink = client
+                        .copy_in(header.as_str())
+                        .await
+                        .with_context(|| format!("failed to start COPY for {qname}"))?;
+                    let mut sink = Box::pin(sink);
+                    let data_bytes = bytes::Bytes::from(data.clone());
+                    futures_util::SinkExt::send(&mut sink, data_bytes)
+                        .await
+                        .context("failed to send COPY data")?;
+                    futures_util::SinkExt::close(&mut sink)
+                        .await
+                        .context("failed to finish COPY")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Restore a plain-format SQL dump to a database.
 pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
     let conninfo = crate::build_conninfo(&opts.dbname);

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1174,10 +1174,47 @@ fn run_defaults() {
 fn run_defaults_custom_format() {}
 
 #[test]
-#[ignore]
 /// defaults_dir_format: pg_dump --format=directory → pg_restore round-trip.
 /// Checks directory structure (toc.dat, blobs_*.toc, *.dat[.gz]).
-fn run_defaults_dir_format() {}
+fn run_defaults_dir_format() {
+    crate::common::setup_test_schema();
+    let out_dir = "/tmp/test_dir_dump";
+    let _ = std::fs::remove_dir_all(out_dir);
+
+    // dump
+    let (_, stderr, code) = crate::common::run_pg_dump(&[
+        "-F",
+        "directory",
+        "-t",
+        "dump_test_simple",
+        "-d",
+        "postgres",
+        "-f",
+        out_dir,
+    ]);
+    assert_eq!(code, 0, "pg_dump -F directory failed: {stderr}");
+    assert!(
+        std::path::Path::new(&format!("{out_dir}/toc.dat")).exists(),
+        "toc.dat should exist"
+    );
+
+    // restore round-trip
+    let test_db = "pg_plumbing_dir_test";
+    crate::common::create_test_db(test_db);
+
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_pg_plumbing"))
+        .args(["pg-restore", "-d", test_db, out_dir])
+        .env("PGPASSWORD", "postgres")
+        .status()
+        .expect("pg_restore should run");
+    assert!(status.success(), "pg_restore of directory dump failed");
+
+    let count = crate::common::psql_query(test_db, "SELECT COUNT(*) FROM dump_test_simple");
+    assert_eq!(count.trim(), "3", "should restore 3 rows, got: {count}");
+
+    crate::common::drop_test_db(test_db);
+    let _ = std::fs::remove_dir_all(out_dir);
+}
 
 #[test]
 #[ignore]


### PR DESCRIPTION
Closes #14

Implements pg_dump directory format:
- Creates output directory with toc.dat + per-table .dat files
- pg_restore detects directory input, reads toc.dat + data files
- Round-trip test: dump -F directory → restore → verify row count