### PR TITLE
feat: custom format i32 overflow + end-of-data marker hardening (#20)

### DIFF
--- a/src/dump/custom_format.rs
+++ b/src/dump/custom_format.rs
@@ -272,11 +272,22 @@ pub fn write_data_block(w: &mut impl Write, dump_id: i32, data: &[u8]) -> io::Re
     // Compress the data.
     let compressed = compress_zlib(data)?;
 
+    // Guard against silent i32 overflow for tables with >2GB of compressed data.
+    let compressed_len = i32::try_from(compressed.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "compressed data length {} exceeds i32::MAX; cannot write data block",
+                compressed.len()
+            ),
+        )
+    })?;
+
     // Block header: type + dump_id.
     w.write_all(&[BLK_DATA])?;
     write_int(w, dump_id)?;
     // Compressed data size.
-    write_int(w, compressed.len() as i32)?;
+    write_int(w, compressed_len)?;
     // Compressed data.
     w.write_all(&compressed)?;
 
@@ -497,12 +508,30 @@ pub fn read_next_data_block(r: &mut impl std::io::Read) -> io::Result<Option<(i3
             let mut decompressed = Vec::new();
             decoder.read_to_end(&mut decompressed)?;
 
-            // Skip the end-of-data marker (BLK_DATA + dump_id + size=0).
+            // Validate the end-of-data marker (BLK_DATA + dump_id + size=0).
+            // A corrupt or truncated archive must produce a clear error.
             let mut marker_type = [0u8; 1];
             r.read_exact(&mut marker_type)?;
-            if marker_type[0] == BLK_DATA {
-                let _id = read_int(r)?;
-                let _sz = read_int(r)?;
+            if marker_type[0] != BLK_DATA {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "invalid end-of-data marker byte: expected BLK_DATA ({}), got {}",
+                        BLK_DATA, marker_type[0]
+                    ),
+                ));
+            }
+            let _marker_id = read_int(r)?;
+            let marker_size = read_int(r)?;
+            if marker_size != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "corrupt archive: end-of-data marker has non-zero size {} (expected 0); \
+                         archive may be truncated",
+                        marker_size
+                    ),
+                ));
             }
 
             Ok(Some((dump_id, decompressed)))

--- a/src/dump/custom_format.rs
+++ b/src/dump/custom_format.rs
@@ -269,10 +269,26 @@ pub fn write_toc_entry(w: &mut impl Write, entry: &TocEntry) -> io::Result<()> {
 ///   - compressed data
 ///   - BLK_DATA + dump_id + size=0 (end-of-data marker for this entry)
 pub fn write_data_block(w: &mut impl Write, dump_id: i32, data: &[u8]) -> io::Result<()> {
-    // Compress the data.
     let compressed = compress_zlib(data)?;
+    write_data_block_compressed(w, dump_id, &compressed)
+}
 
-    // Guard against silent i32 overflow for tables with >2GB of compressed data.
+/// Write a pre-compressed data block for one TOC entry.
+///
+/// This is the inner implementation used by `write_data_block` after
+/// compression. Exposed as `pub(crate)` so that tests can inject an
+/// already-"compressed" buffer of arbitrary length (including one that
+/// exceeds `i32::MAX`) without having to allocate >2 GB of actual memory.
+///
+/// The overflow guard lives here — removing it from this function will
+/// cause `write_data_block_len_overflow_returns_error` to fail.
+pub fn write_data_block_compressed(
+    w: &mut impl Write,
+    dump_id: i32,
+    compressed: &[u8],
+) -> io::Result<()> {
+    // Guard against an incorrect truncating cast for tables whose compressed
+    // output would exceed i32::MAX bytes.
     let compressed_len = i32::try_from(compressed.len()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -289,7 +305,7 @@ pub fn write_data_block(w: &mut impl Write, dump_id: i32, data: &[u8]) -> io::Re
     // Compressed data size.
     write_int(w, compressed_len)?;
     // Compressed data.
-    w.write_all(&compressed)?;
+    w.write_all(compressed)?;
 
     // End-of-data marker: another BLK_DATA with size=0.
     w.write_all(&[BLK_DATA])?;
@@ -494,8 +510,19 @@ pub fn read_next_data_block(r: &mut impl std::io::Read) -> io::Result<Option<(i3
             let compressed_size = read_int(r)?;
 
             if compressed_size <= 0 {
-                // End-of-data marker for a previous entry or zero-size block.
-                return Ok(Some((dump_id, Vec::new())));
+                // A non-positive compressed_size is invalid: valid data blocks always
+                // have a positive size (zlib output for empty input is 8 bytes), and
+                // end-of-data markers (size=0) are consumed inside the positive-size
+                // path below. Returning an error here avoids silently swallowing a
+                // corrupt or truncated block.
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "invalid block: compressed_size {} is non-positive for dump_id {}; \
+                         archive may be corrupt or truncated",
+                        compressed_size, dump_id
+                    ),
+                ));
             }
 
             let mut compressed = vec![0u8; compressed_size as usize];
@@ -521,7 +548,17 @@ pub fn read_next_data_block(r: &mut impl std::io::Read) -> io::Result<Option<(i3
                     ),
                 ));
             }
-            let _marker_id = read_int(r)?;
+            let marker_id = read_int(r)?;
+            if marker_id != dump_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "corrupt archive: end-of-data marker dump_id {} != block dump_id {}; \
+                         archive may be spliced or truncated",
+                        marker_id, dump_id
+                    ),
+                ));
+            }
             let marker_size = read_int(r)?;
             if marker_size != 0 {
                 return Err(io::Error::new(

--- a/tests/pg_dump/mod.rs
+++ b/tests/pg_dump/mod.rs
@@ -8,4 +8,5 @@ mod t002_pg_dump;
 mod t003_pg_dump_with_server;
 mod t004_pg_dump_parallel;
 mod t005_dir_format_dedup;
+mod t006_custom_format_hardening;
 mod t010_dump_connstr;

--- a/tests/pg_dump/t005_dir_format_dedup.rs
+++ b/tests/pg_dump/t005_dir_format_dedup.rs
@@ -60,6 +60,12 @@ fn setup_shared_sequence_schema() {
         // Step 2: inject a second `deptype='a'` row so that the sequence appears
         // when querying dependencies for BOTH tables.  This is the exact condition
         // that triggers the duplicate-emission bug in dump_directory.
+        //
+        // Note: in real PostgreSQL, SEQUENCE OWNED BY table.col sets refobjsubid
+        // to the column's attnum (not 0). We use refobjsubid=0 here (table-level
+        // dependency) because get_table_sequences() does not filter on refobjsubid,
+        // so this still triggers and validates the dedup fix while keeping the
+        // test setup simpler and self-contained.
         let inject_sql = "
             INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
             SELECT

--- a/tests/pg_dump/t006_custom_format_hardening.rs
+++ b/tests/pg_dump/t006_custom_format_hardening.rs
@@ -5,7 +5,9 @@
 //! 1. i32 overflow guard in write_data_block for large compressed data.
 //! 2. End-of-data marker validation in read_next_data_block.
 
-use pg_plumbing::dump::custom_format::{read_next_data_block, write_data_block, BLK_DATA, BLK_EOF};
+use pg_plumbing::dump::custom_format::{
+    read_next_data_block, write_data_block, write_data_block_compressed, BLK_DATA, BLK_EOF,
+};
 use std::io::Cursor;
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -13,20 +15,42 @@ use std::io::Cursor;
 // ──────────────────────────────────────────────────────────────────────────────
 
 /// write_data_block must return an error when the compressed output would
-/// exceed i32::MAX bytes (instead of silently wrapping the cast).
+/// exceed i32::MAX bytes.
 ///
-/// We verify the same checked-cast logic that write_data_block now uses,
-/// confirming i32::try_from properly rejects oversized lengths.
+/// We call `write_data_block_compressed` — the inner function that owns the
+/// overflow guard — with a fake pre-"compressed" slice whose length is
+/// i32::MAX + 1.  This avoids allocating >2 GB while still exercising the
+/// exact `i32::try_from` check in production code.
+///
+/// This test **will fail** if the guard is removed from
+/// `write_data_block_compressed`.
 #[test]
 fn write_data_block_len_overflow_returns_error() {
-    // Verify that i32::try_from correctly rejects values > i32::MAX.
-    // This is the same checked-cast logic now used inside write_data_block.
-    let oversized: usize = (i32::MAX as usize) + 1;
-    let result = i32::try_from(oversized);
+    // Build a 1-byte backing buffer and reinterpret its length via a raw-slice
+    // fat pointer so we never allocate >2 GB.  The writer is a sink — it will
+    // error before any bytes are written because the overflow check runs first.
+    let backing = [0u8; 1];
+    let oversized_len = (i32::MAX as usize) + 1;
+    // SAFETY: we construct a slice header with a fake length. The overflow
+    // guard in write_data_block_compressed checks `compressed.len()` before
+    // doing any memory access into the slice, so the backing store is never
+    // read beyond its real size.
+    let oversized: &[u8] = unsafe { std::slice::from_raw_parts(backing.as_ptr(), oversized_len) };
+
+    let mut sink = Vec::new();
+    let result = write_data_block_compressed(&mut sink, 1, oversized);
     assert!(
         result.is_err(),
-        "i32::try_from on oversized len must fail — sanity check for the guard logic"
+        "write_data_block_compressed must error when compressed len > i32::MAX"
     );
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("i32::MAX") || msg.contains("exceeds"),
+        "error message should mention the overflow, got: {err}"
+    );
+    // The writer must not have been touched (guard fires before any write).
+    assert!(sink.is_empty(), "no bytes must be written on overflow");
 }
 
 /// write_data_block succeeds for normal-sized data and round-trips correctly.
@@ -48,20 +72,26 @@ fn write_data_block_normal_data_roundtrips() {
     assert_eq!(decompressed, data);
 }
 
-/// write_data_block with empty data still writes a valid block (size=0 path).
+/// write_data_block with empty data still writes a valid block.
+/// Note: zlib output for empty input is ~8 bytes (not size=0), so the
+/// compressed_size field in the block is positive.
 #[test]
 fn write_data_block_empty_data_roundtrips() {
     let mut buf = Vec::new();
     write_data_block(&mut buf, 7, b"").expect("write_data_block must succeed for empty data");
 
     let mut cursor = Cursor::new(&buf);
-    // No error must be raised reading an empty-data block.
     let result = read_next_data_block(&mut cursor);
     assert!(
         result.is_ok(),
         "empty block must not produce an error: {:?}",
         result
     );
+    let block = result
+        .unwrap()
+        .expect("must return Some for an empty-data block");
+    assert_eq!(block.0, 7, "dump_id must round-trip");
+    assert!(block.1.is_empty(), "decompressed data must be empty");
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -140,6 +170,39 @@ fn read_next_data_block_nonzero_marker_size_returns_error() {
             || msg.contains("size")
             || msg.contains("truncat"),
         "error message should describe the problem, got: {err}"
+    );
+}
+
+/// A corrupt archive where the end-of-data marker dump_id mismatches the
+/// block dump_id must return an error (spliced-archive detection).
+#[test]
+fn read_next_data_block_mismatched_marker_id_returns_error() {
+    let mut buf = make_valid_block(10, b"hello world");
+
+    // End-of-data marker layout (last 11 bytes):
+    //   offset 0:   BLK_DATA
+    //   offset 1-5: write_int(dump_id=10)
+    //   offset 6-10: write_int(0)
+    let marker_start = buf.len() - 11;
+
+    // Overwrite the marker dump_id (bytes 1-5) with write_int(99).
+    let id_offset = marker_start + 1;
+    buf[id_offset] = 1u8; // sign = positive
+    let val_bytes = 99u32.to_le_bytes();
+    buf[id_offset + 1..id_offset + 5].copy_from_slice(&val_bytes);
+
+    let mut cursor = Cursor::new(&buf);
+    let result = read_next_data_block(&mut cursor);
+    assert!(
+        result.is_err(),
+        "mismatched marker dump_id must return an error, got: {:?}",
+        result
+    );
+    let err = result.unwrap_err();
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("marker") || msg.contains("corrupt") || msg.contains("dump_id"),
+        "error message should describe the mismatch, got: {err}"
     );
 }
 

--- a/tests/pg_dump/t006_custom_format_hardening.rs
+++ b/tests/pg_dump/t006_custom_format_hardening.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 pg_plumbing contributors
+// SPDX-License-Identifier: MIT
+
+//! Hardening tests for custom_format.rs:
+//! 1. i32 overflow guard in write_data_block for large compressed data.
+//! 2. End-of-data marker validation in read_next_data_block.
+
+use pg_plumbing::dump::custom_format::{read_next_data_block, write_data_block, BLK_DATA, BLK_EOF};
+use std::io::Cursor;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fix 1: i32 overflow guard in write_data_block
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// write_data_block must return an error when the compressed output would
+/// exceed i32::MAX bytes (instead of silently wrapping the cast).
+///
+/// We verify the same checked-cast logic that write_data_block now uses,
+/// confirming i32::try_from properly rejects oversized lengths.
+#[test]
+fn write_data_block_len_overflow_returns_error() {
+    // Verify that i32::try_from correctly rejects values > i32::MAX.
+    // This is the same checked-cast logic now used inside write_data_block.
+    let oversized: usize = (i32::MAX as usize) + 1;
+    let result = i32::try_from(oversized);
+    assert!(
+        result.is_err(),
+        "i32::try_from on oversized len must fail — sanity check for the guard logic"
+    );
+}
+
+/// write_data_block succeeds for normal-sized data and round-trips correctly.
+#[test]
+fn write_data_block_normal_data_roundtrips() {
+    let data = b"COPY users (id, name) FROM stdin;\n1\tAlice\n2\tBob\n\\.\n";
+    let mut buf = Vec::new();
+    write_data_block(&mut buf, 42, data).expect("write_data_block must succeed for small data");
+
+    // The buffer must start with BLK_DATA.
+    assert_eq!(buf[0], BLK_DATA, "first byte must be BLK_DATA");
+
+    // Read back via read_next_data_block.
+    let mut cursor = Cursor::new(&buf);
+    let result = read_next_data_block(&mut cursor)
+        .expect("read_next_data_block must not error on valid data");
+    let (id, decompressed) = result.expect("must return Some for a data block");
+    assert_eq!(id, 42);
+    assert_eq!(decompressed, data);
+}
+
+/// write_data_block with empty data still writes a valid block (size=0 path).
+#[test]
+fn write_data_block_empty_data_roundtrips() {
+    let mut buf = Vec::new();
+    write_data_block(&mut buf, 7, b"").expect("write_data_block must succeed for empty data");
+
+    let mut cursor = Cursor::new(&buf);
+    // No error must be raised reading an empty-data block.
+    let result = read_next_data_block(&mut cursor);
+    assert!(
+        result.is_ok(),
+        "empty block must not produce an error: {:?}",
+        result
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fix 2: end-of-data marker validation in read_next_data_block
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Helper: build a valid compressed data block buffer for dump_id.
+fn make_valid_block(dump_id: i32, data: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_data_block(&mut buf, dump_id, data).unwrap();
+    buf
+}
+
+/// A corrupt archive where the end-of-data marker byte is wrong (not BLK_DATA)
+/// must return an error.
+#[test]
+fn read_next_data_block_bad_marker_byte_returns_error() {
+    // Build a valid block first.
+    let mut buf = make_valid_block(1, b"hello world");
+
+    // The end-of-data marker is: BLK_DATA(1) + write_int(id)(5) + write_int(0)(5) = 11 bytes
+    let marker_start = buf.len() - 11;
+    // Corrupt the marker byte to something invalid (e.g. 0x42).
+    buf[marker_start] = 0x42;
+
+    let mut cursor = Cursor::new(&buf);
+    let result = read_next_data_block(&mut cursor);
+    assert!(
+        result.is_err(),
+        "corrupt end-of-data marker byte must return an error, got: {:?}",
+        result
+    );
+    let err = result.unwrap_err();
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("marker")
+            || msg.contains("corrupt")
+            || msg.contains("invalid")
+            || msg.contains("end"),
+        "error message should describe the problem, got: {err}"
+    );
+}
+
+/// A corrupt archive where the end-of-data marker size field is nonzero
+/// (indicating a truncated or corrupt archive) must return an error.
+#[test]
+fn read_next_data_block_nonzero_marker_size_returns_error() {
+    let mut buf = make_valid_block(1, b"hello world");
+
+    // End-of-data marker layout (last 11 bytes):
+    //   offset 0: BLK_DATA (0x01)
+    //   offset 1-5: write_int(dump_id) — sign byte + 4 LE bytes
+    //   offset 6-10: write_int(0)      — sign byte + 4 LE bytes (the size=0 field)
+    let marker_start = buf.len() - 11;
+
+    // Overwrite the size field (bytes 6-10 of the marker) with write_int(999).
+    // write_int layout: [sign_byte=1, val_le32]
+    let size_offset = marker_start + 6;
+    buf[size_offset] = 1u8; // sign = positive
+    let val_bytes = 999u32.to_le_bytes();
+    buf[size_offset + 1..size_offset + 5].copy_from_slice(&val_bytes);
+
+    let mut cursor = Cursor::new(&buf);
+    let result = read_next_data_block(&mut cursor);
+    assert!(
+        result.is_err(),
+        "nonzero end-of-data marker size must return an error, got: {:?}",
+        result
+    );
+    let err = result.unwrap_err();
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("marker")
+            || msg.contains("corrupt")
+            || msg.contains("invalid")
+            || msg.contains("size")
+            || msg.contains("truncat"),
+        "error message should describe the problem, got: {err}"
+    );
+}
+
+/// A valid archive round-trips through read_next_data_block followed by BLK_EOF.
+#[test]
+fn read_next_data_block_followed_by_eof() {
+    let data = b"some table data\n";
+    let mut buf = make_valid_block(5, data);
+    buf.push(BLK_EOF);
+
+    let mut cursor = Cursor::new(&buf);
+
+    // First call: data block.
+    let block = read_next_data_block(&mut cursor)
+        .expect("must not error")
+        .expect("must be Some");
+    assert_eq!(block.0, 5);
+    assert_eq!(block.1, data);
+
+    // Second call: EOF.
+    let eof = read_next_data_block(&mut cursor).expect("must not error on EOF");
+    assert!(eof.is_none(), "must return None at BLK_EOF");
+}
+
+/// Marker with correct byte and size=0 does not produce an error (positive case).
+#[test]
+fn read_next_data_block_valid_marker_ok() {
+    let data = b"id\tname\n1\tAlice\n";
+    let buf = make_valid_block(3, data);
+    let mut cursor = Cursor::new(&buf);
+    let result = read_next_data_block(&mut cursor);
+    assert!(result.is_ok(), "valid block must not error: {:?}", result);
+    let block = result.unwrap().expect("must be Some");
+    assert_eq!(block.0, 3);
+    assert_eq!(block.1, data);
+}


### PR DESCRIPTION
Fixes #20

## Goal
Two minor hardening items from REV review:
1. `compressed.len() as i32` checked cast — returns io::Error if data exceeds i32::MAX (avoids silent overflow for >2GB tables)
2. `read_next_data_block` now validates end-of-data marker byte and size field — corrupt/truncated archives produce clear errors instead of silent misbehavior

## What changed
- `src/dump/custom_format.rs`: checked cast + marker validation
- `tests/pg_dump/t006_custom_format_hardening.rs`: new hardening tests (not ignored)

## How to verify
`cargo test t006` — all new tests pass