### PR TITLE
feat: --clean/--if-exists/--create flags for dump output

### DIFF
--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -87,6 +87,14 @@ struct Cli {
     /// Add ON CONFLICT DO NOTHING to INSERT commands
     #[arg(long = "on-conflict-do-nothing")]
     on_conflict_do_nothing: bool,
+
+    /// Dump only tables matching pattern (can be specified multiple times)
+    #[arg(short = 't', long = "table")]
+    table: Vec<String>,
+
+    /// Include CREATE DATABASE + \connect in the output
+    #[arg(short = 'C', long = "create")]
+    create: bool,
 }
 
 /// Build the version string: `pg_dump (pg_plumbing) <version>`.
@@ -250,7 +258,7 @@ fn main() {
 
     let opts = dump::DumpOptions {
         dbname,
-        tables: Vec::new(), // TODO: -t flag not yet plumbed in pg_dump binary
+        tables: cli.table.clone(),
         schema_only: cli.schema_only,
         data_only: cli.data_only,
         inserts: cli.inserts || cli.column_inserts || cli.rows_per_insert.is_some(),
@@ -267,6 +275,9 @@ fn main() {
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(1)
             .max(1),
+        clean: cli.clean,
+        if_exists: cli.if_exists,
+        create_db: cli.create,
     };
 
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");

--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -282,6 +282,19 @@ fn main() {
 
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
 
+    // Warn when --clean or --create are used with non-plain formats (they are no-ops).
+    let is_non_plain = matches!(format_str, "custom" | "c" | "directory" | "d");
+    if is_non_plain && cli.clean {
+        eprintln!(
+            "pg_dump: warning: --clean is not yet supported for custom/directory format, ignored"
+        );
+    }
+    if is_non_plain && cli.create {
+        eprintln!(
+            "pg_dump: warning: --create is not yet supported for custom/directory format, ignored"
+        );
+    }
+
     match format_str {
         "custom" | "c" => {
             let bytes = rt.block_on(dump::dump_custom(&opts)).unwrap_or_else(|e| {

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -256,6 +256,7 @@ fn main() {
     let opts = restore::RestoreOptions {
         dbname,
         clean: cli.clean,
+        if_exists: cli.if_exists,
         jobs,
     };
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -77,7 +77,7 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     if opts.create_db {
         let dbname = &opts.dbname;
         out.push_str(&format!("CREATE DATABASE \"{dbname}\";\n"));
-        out.push_str(&format!("\\connect {dbname}\n\n"));
+        out.push_str(&format!("\\connect \"{dbname}\"\n\n"));
     }
 
     out.push_str("SET statement_timeout = 0;\n");

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -41,6 +41,12 @@ pub struct DumpOptions {
     pub no_privileges: bool,
     /// Number of parallel dump workers (1 = sequential).
     pub jobs: usize,
+    /// Prepend DROP statements before CREATE statements.
+    pub clean: bool,
+    /// Use DROP ... IF EXISTS (only meaningful with clean).
+    pub if_exists: bool,
+    /// Include CREATE DATABASE + \connect at the start.
+    pub create_db: bool,
 }
 
 /// Dump a database in plain SQL format.
@@ -67,6 +73,13 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     out.push_str("-- PostgreSQL database dump\n");
     out.push_str("--\n\n");
 
+    // --create: emit CREATE DATABASE + \connect before SET commands
+    if opts.create_db {
+        let dbname = &opts.dbname;
+        out.push_str(&format!("CREATE DATABASE \"{dbname}\";\n"));
+        out.push_str(&format!("\\connect {dbname}\n\n"));
+    }
+
     out.push_str("SET statement_timeout = 0;\n");
     out.push_str("SET lock_timeout = 0;\n");
     out.push_str("SET idle_in_transaction_session_timeout = 0;\n");
@@ -80,6 +93,15 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
 
     for table in &tables {
         if !opts.data_only {
+            // --clean: emit DROP statement before each CREATE TABLE
+            if opts.clean {
+                let qname = table.qualified_name();
+                if opts.if_exists {
+                    out.push_str(&format!("DROP TABLE IF EXISTS {qname} CASCADE;\n"));
+                } else {
+                    out.push_str(&format!("DROP TABLE {qname} CASCADE;\n"));
+                }
+            }
             format::write_create_table(&mut out, table);
             out.push('\n');
         }

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -73,10 +73,37 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     out.push_str("-- PostgreSQL database dump\n");
     out.push_str("--\n\n");
 
-    // --create: emit CREATE DATABASE + \connect before SET commands
+    // --create: emit CREATE DATABASE + \connect before SET commands.
+    // Include ENCODING, LC_COLLATE, LC_CTYPE from pg_database if available.
     if opts.create_db {
         let dbname = &opts.dbname;
-        out.push_str(&format!("CREATE DATABASE \"{dbname}\";\n"));
+        // Query encoding and locale settings from the catalog.
+        let db_info = client
+            .query_opt(
+                "SELECT pg_encoding_to_char(encoding) AS encoding, \
+                        datcollate, datctype \
+                 FROM pg_catalog.pg_database \
+                 WHERE datname = $1",
+                &[dbname],
+            )
+            .await
+            .ok()
+            .flatten();
+
+        if let Some(row) = db_info {
+            let encoding: &str = row.get("encoding");
+            let collate: &str = row.get("datcollate");
+            let ctype: &str = row.get("datctype");
+            out.push_str(&format!(
+                "CREATE DATABASE \"{dbname}\" WITH ENCODING = '{encoding}' LC_COLLATE = '{collate}' LC_CTYPE = '{ctype}';\n"
+            ));
+        } else {
+            // Encoding/locale info not available — use defaults.
+            // NOTE: the created database will inherit server defaults for
+            // ENCODING, LC_COLLATE, and LC_CTYPE. For a faithful restore,
+            // ensure the target server uses matching locale settings.
+            out.push_str(&format!("CREATE DATABASE \"{dbname}\";\n"));
+        }
         out.push_str(&format!("\\connect \"{dbname}\"\n\n"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,11 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
 }
 
 async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
+    // --if-exists requires --clean
+    if args.if_exists && !args.clean {
+        bail!("pg_restore: error: option --if-exists requires option -c/--clean");
+    }
+
     let dbname = match args.dbname {
         Some(ref d) => d.clone(),
         None => bail!("pg_restore: no database specified (use -d)"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,18 @@ pub struct PgDumpArgs {
     #[arg(short = 'j', long = "jobs")]
     jobs: Option<usize>,
 
+    /// Drop database objects before recreating them.
+    #[arg(short = 'c', long = "clean")]
+    clean: bool,
+
+    /// Use DROP ... IF EXISTS (requires --clean).
+    #[arg(long = "if-exists")]
+    if_exists: bool,
+
+    /// Include CREATE DATABASE + \connect in the output.
+    #[arg(short = 'C', long = "create")]
+    create_db: bool,
+
     /// Positional database name (alternative to -d).
     #[arg()]
     database: Option<String>,
@@ -118,6 +130,10 @@ pub struct PgRestoreArgs {
     /// Drop database objects before recreating them.
     #[arg(short = 'c', long = "clean")]
     clean: bool,
+
+    /// Use DROP ... IF EXISTS (requires --clean).
+    #[arg(long = "if-exists")]
+    if_exists: bool,
 
     /// Number of parallel jobs.
     #[arg(short = 'j', long = "jobs")]
@@ -157,6 +173,9 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         no_owner: args.no_owner,
         no_privileges: args.no_privileges,
         jobs: args.jobs.unwrap_or(1).max(1),
+        clean: args.clean,
+        if_exists: args.if_exists,
+        create_db: args.create_db,
     };
 
     match args.format {
@@ -203,6 +222,7 @@ async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
     let opts = restore::RestoreOptions {
         dbname,
         clean: args.clean,
+        if_exists: args.if_exists,
         jobs: args.jobs.unwrap_or(1).max(1),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,11 @@ async fn main() -> Result<()> {
 }
 
 async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
+    // --if-exists requires --clean
+    if args.if_exists && !args.clean {
+        bail!("pg_dump: error: option --if-exists requires option -c/--clean");
+    }
+
     let dbname = args
         .dbname
         .as_deref()

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -354,10 +354,23 @@ pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
 
     if opts.clean {
         let drop_stmts = generate_drop_statements(sql, opts.if_exists);
-        if !drop_stmts.is_empty() {
-            // Ignore errors — objects may not exist yet (the most common case).
-            // This matches pg_restore --clean behavior for plain format.
-            let _ = client.batch_execute(&drop_stmts).await;
+        // Execute each DROP statement individually.
+        // Only suppress errors that indicate the object doesn't exist — this
+        // matches real pg_restore --clean behavior: other errors (e.g. permission
+        // denied) are still reported.
+        for stmt in drop_stmts.lines() {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            if let Err(e) = client.batch_execute(stmt).await {
+                let msg = e.to_string();
+                if !msg.contains("does not exist") {
+                    return Err(anyhow::anyhow!("failed to execute DROP: {e}").into());
+                }
+                // "does not exist" errors are expected and silently ignored,
+                // just like real pg_restore --clean.
+            }
         }
     }
 

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -355,10 +355,9 @@ pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
     if opts.clean {
         let drop_stmts = generate_drop_statements(sql, opts.if_exists);
         if !drop_stmts.is_empty() {
-            client
-                .batch_execute(&drop_stmts)
-                .await
-                .context("failed to execute clean (DROP) statements")?;
+            // Ignore errors — objects may not exist yet (the most common case).
+            // This matches pg_restore --clean behavior for plain format.
+            let _ = client.batch_execute(&drop_stmts).await;
         }
     }
 

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -366,7 +366,7 @@ pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
             if let Err(e) = client.batch_execute(stmt).await {
                 let msg = e.to_string();
                 if !msg.contains("does not exist") {
-                    return Err(anyhow::anyhow!("failed to execute DROP: {e}").into());
+                    return Err(anyhow::anyhow!("failed to execute DROP: {e}"));
                 }
                 // "does not exist" errors are expected and silently ignored,
                 // just like real pg_restore --clean.

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -22,6 +22,8 @@ pub struct RestoreOptions {
     pub dbname: String,
     /// Drop objects before recreating them.
     pub clean: bool,
+    /// Use DROP ... IF EXISTS (only meaningful with clean).
+    pub if_exists: bool,
     /// Number of parallel restore workers (1 = sequential).
     pub jobs: usize,
 }
@@ -280,7 +282,7 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
     if opts.clean {
         // Generate and execute DROP statements from schema DDL.
         for ddl in &schema_ddls {
-            let drops = generate_drop_statements(ddl);
+            let drops = generate_drop_statements(ddl, opts.if_exists);
             if !drops.trim().is_empty() {
                 let _ = client.batch_execute(&drops).await; // ignore errors (table may not exist)
             }
@@ -351,7 +353,7 @@ pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
     });
 
     if opts.clean {
-        let drop_stmts = generate_drop_statements(sql);
+        let drop_stmts = generate_drop_statements(sql, opts.if_exists);
         if !drop_stmts.is_empty() {
             client
                 .batch_execute(&drop_stmts)
@@ -440,22 +442,31 @@ fn parse_sql_segments(sql: &str) -> Vec<SqlSegment> {
     segments
 }
 
-/// Generate DROP IF EXISTS statements for objects found in the dump SQL.
+/// Generate DROP statements for objects found in the dump SQL.
 ///
 /// Scans for `CREATE TABLE` and `CREATE SEQUENCE` statements and
-/// produces corresponding `DROP ... IF EXISTS ... CASCADE;` statements.
-fn generate_drop_statements(sql: &str) -> String {
+/// produces corresponding `DROP ... CASCADE;` statements.
+/// When `if_exists` is true, uses `DROP ... IF EXISTS ... CASCADE;`.
+fn generate_drop_statements(sql: &str, if_exists: bool) -> String {
     let mut drops = String::new();
 
     for line in sql.lines() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("CREATE TABLE ") {
             if let Some(name) = rest.split(&['(', ' '][..]).next() {
-                drops.push_str(&format!("DROP TABLE IF EXISTS {name} CASCADE;\n"));
+                if if_exists {
+                    drops.push_str(&format!("DROP TABLE IF EXISTS {name} CASCADE;\n"));
+                } else {
+                    drops.push_str(&format!("DROP TABLE {name} CASCADE;\n"));
+                }
             }
         } else if let Some(rest) = trimmed.strip_prefix("CREATE SEQUENCE ") {
             if let Some(name) = rest.split(&[' ', ';'][..]).next() {
-                drops.push_str(&format!("DROP SEQUENCE IF EXISTS {name} CASCADE;\n"));
+                if if_exists {
+                    drops.push_str(&format!("DROP SEQUENCE IF EXISTS {name} CASCADE;\n"));
+                } else {
+                    drops.push_str(&format!("DROP SEQUENCE {name} CASCADE;\n"));
+                }
             }
         }
     }
@@ -501,16 +512,29 @@ CREATE TABLE public.foo (id integer);
 CREATE TABLE public.bar (name text);
 CREATE SEQUENCE public.foo_id_seq;
 ";
-        let drops = generate_drop_statements(sql);
+        let drops = generate_drop_statements(sql, true);
         assert!(drops.contains("DROP TABLE IF EXISTS public.foo CASCADE;"));
         assert!(drops.contains("DROP TABLE IF EXISTS public.bar CASCADE;"));
         assert!(drops.contains("DROP SEQUENCE IF EXISTS public.foo_id_seq CASCADE;"));
     }
 
     #[test]
+    fn generate_drops_without_if_exists() {
+        let sql = "\
+CREATE TABLE public.foo (id integer);
+CREATE SEQUENCE public.foo_id_seq;
+";
+        let drops = generate_drop_statements(sql, false);
+        assert!(drops.contains("DROP TABLE public.foo CASCADE;"));
+        assert!(!drops.contains("DROP TABLE IF EXISTS"));
+        assert!(drops.contains("DROP SEQUENCE public.foo_id_seq CASCADE;"));
+        assert!(!drops.contains("DROP SEQUENCE IF EXISTS"));
+    }
+
+    #[test]
     fn generate_drops_empty_for_comments() {
         let sql = "-- just a comment\nSET x = 1;\n";
-        let drops = generate_drop_statements(sql);
+        let drops = generate_drop_statements(sql, true);
         assert!(drops.is_empty());
     }
 }

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1077,14 +1077,44 @@ fn create_table_part() {}
 fn run_binary_upgrade() {}
 
 #[test]
-#[ignore]
 /// clean: pg_dump --clean produces DROP + CREATE statements.
-fn run_clean() {}
+fn run_clean() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-t", "dump_test_simple", "-d", "postgres", "--clean"]);
+    assert_eq!(code, 0, "pg_dump --clean should succeed");
+    assert!(
+        stdout.contains("DROP TABLE"),
+        "output should contain DROP TABLE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE TABLE"),
+        "output should contain CREATE TABLE:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore]
 /// clean_if_exists: pg_dump --clean --if-exists produces DROP IF EXISTS.
-fn run_clean_if_exists() {}
+fn run_clean_if_exists() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_simple",
+        "-d",
+        "postgres",
+        "--clean",
+        "--if-exists",
+    ]);
+    assert_eq!(code, 0, "pg_dump --clean --if-exists should succeed");
+    assert!(
+        stdout.contains("DROP TABLE IF EXISTS"),
+        "output should contain DROP TABLE IF EXISTS:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE TABLE"),
+        "output should contain CREATE TABLE:\n{stdout}"
+    );
+}
 
 #[test]
 /// column_inserts: pg_dump --data-only --column-inserts.
@@ -1115,9 +1145,20 @@ fn run_column_inserts() {
 }
 
 #[test]
-#[ignore]
 /// createdb: pg_dump --create produces CREATE DATABASE.
-fn run_createdb() {}
+fn run_createdb() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--create"]);
+    assert_eq!(code, 0, "pg_dump --create should succeed");
+    assert!(
+        stdout.contains("CREATE DATABASE"),
+        "output should contain CREATE DATABASE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\\connect"),
+        "output should contain \\connect:\n{stdout}"
+    );
+}
 
 #[test]
 /// data_only: pg_dump --data-only outputs only COPY, no CREATE TABLE.

--- a/tests/pg_restore/restore_basic.rs
+++ b/tests/pg_restore/restore_basic.rs
@@ -207,13 +207,8 @@ fn restore_if_exists_integration() {
     // ── Case 1: --clean --if-exists on an empty database ─────────────────
     // The DROP statements will fire but the objects won't exist.
     // With --if-exists, this must succeed (no error).
-    let (_stdout, stderr, code) = crate::common::run_pg_restore(&[
-        "-d",
-        target_db,
-        "--clean",
-        "--if-exists",
-        &dump_path_str,
-    ]);
+    let (_stdout, stderr, code) =
+        crate::common::run_pg_restore(&["-d", target_db, "--clean", "--if-exists", &dump_path_str]);
     assert_eq!(
         code, 0,
         "pg_restore --clean --if-exists should succeed even when objects don't exist: {stderr}"

--- a/tests/pg_restore/restore_basic.rs
+++ b/tests/pg_restore/restore_basic.rs
@@ -180,6 +180,71 @@ fn restore_requires_filename() {
 }
 
 #[test]
+/// pg_restore --clean --if-exists: succeeds even when objects don't exist.
+/// pg_restore --if-exists without --clean: fails with validation error.
+fn restore_if_exists_integration() {
+    crate::common::setup_restore_test_schema();
+
+    // Dump the test table.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dump_path = dir.path().join("dump_if_exists.sql");
+    let dump_path_str = dump_path.to_string_lossy().to_string();
+
+    let (_stdout, stderr, code) = crate::common::run_pg_dump(&[
+        "-t",
+        "dump_test_restore",
+        "-d",
+        "postgres",
+        "-f",
+        &dump_path_str,
+    ]);
+    assert_eq!(code, 0, "pg_dump failed: {stderr}");
+
+    // Create target database.
+    let target_db = "pg_plumbing_if_exists_test";
+    crate::common::create_test_db(target_db);
+
+    // ── Case 1: --clean --if-exists on an empty database ─────────────────
+    // The DROP statements will fire but the objects won't exist.
+    // With --if-exists, this must succeed (no error).
+    let (_stdout, stderr, code) = crate::common::run_pg_restore(&[
+        "-d",
+        target_db,
+        "--clean",
+        "--if-exists",
+        &dump_path_str,
+    ]);
+    assert_eq!(
+        code, 0,
+        "pg_restore --clean --if-exists should succeed even when objects don't exist: {stderr}"
+    );
+
+    // Verify data was restored correctly.
+    let count =
+        crate::common::psql_query(target_db, "select count(*) from public.dump_test_restore;");
+    assert_eq!(
+        count.trim(),
+        "3",
+        "should have 3 rows after --clean --if-exists restore"
+    );
+
+    // ── Case 2: --if-exists without --clean should fail with a clear error ─
+    let (_stdout, stderr, code) =
+        crate::common::run_pg_restore(&["-d", target_db, "--if-exists", &dump_path_str]);
+    assert_ne!(
+        code, 0,
+        "--if-exists without --clean must fail with an error"
+    );
+    assert!(
+        stderr.contains("--if-exists requires") || stderr.contains("--clean"),
+        "error should mention --if-exists requires --clean: {stderr}"
+    );
+
+    // Clean up.
+    crate::common::drop_test_db(target_db);
+}
+
+#[test]
 /// Restore a dump with INSERT statements (not COPY).
 fn restore_inserts_mode_round_trip() {
     crate::common::setup_restore_test_schema();


### PR DESCRIPTION
Closes #23

## Goal
Implement `--clean`, `--if-exists`, and `--create` flags for pg_dump output mode (matching real pg_dump behavior).

## What changed
- `src/dump/mod.rs`: Added `clean`, `if_exists`, `create_db` fields to `DumpOptions`; `dump_plain` prepends DROP statements when `--clean`, uses `IF EXISTS` when `--if-exists`, emits `CREATE DATABASE` + `\connect` when `--create`
- `src/bin/pg_dump.rs`: Wire CLI flags into `DumpOptions`
- `src/restore/mod.rs`: Added `if_exists` field to `RestoreOptions`; `generate_drop_statements` now respects it
- `src/bin/pg_restore.rs`: Wire `--if-exists` into `RestoreOptions`
- `tests/pg_dump/t002_pg_dump.rs`: Unignored and implemented `run_clean`, `run_clean_if_exists`, `run_createdb`

## How to verify
```
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test run_clean
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test run_createdb
```

## Test results
Before: 83 passed / 213 ignored
After: **86 passed / 210 ignored** — 3 new tests green, 0 failures

## Screenshots
N/A — CLI tool