### PR TITLE
feat: table and schema filtering (--table, --exclude-table, --schema, --exclude-schema)

### DIFF
--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -92,6 +92,22 @@ struct Cli {
     #[arg(short = 't', long = "table")]
     table: Vec<String>,
 
+    /// Do not dump the named table(s) (can be specified multiple times)
+    #[arg(short = 'T', long = "exclude-table")]
+    exclude_table: Vec<String>,
+
+    /// Dump only the named schema(s) (can be specified multiple times)
+    #[arg(short = 'n', long = "schema")]
+    schema: Vec<String>,
+
+    /// Do not dump the named schema(s) (can be specified multiple times)
+    #[arg(short = 'N', long = "exclude-schema")]
+    exclude_schema: Vec<String>,
+
+    /// Do not dump data for the named table(s) (can be specified multiple times)
+    #[arg(long = "exclude-table-data")]
+    exclude_table_data: Vec<String>,
+
     /// Include CREATE DATABASE + \connect in the output
     #[arg(short = 'C', long = "create")]
     create: bool,
@@ -264,9 +280,10 @@ fn main() {
         inserts: cli.inserts || cli.column_inserts || cli.rows_per_insert.is_some(),
         column_inserts: cli.column_inserts,
         rows_per_insert: cli.rows_per_insert.map(|v| v as u32),
-        schemas: Vec::new(),
-        exclude_schemas: Vec::new(),
-        exclude_tables: Vec::new(),
+        schemas: cli.schema.clone(),
+        exclude_schemas: cli.exclude_schema.clone(),
+        exclude_tables: cli.exclude_table.clone(),
+        exclude_table_data: cli.exclude_table_data.clone(),
         no_owner: false,
         no_privileges: false,
         jobs: cli

--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -67,7 +67,15 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
     let table_rows = if opts.tables.is_empty() {
         // Dump all user tables and partitioned tables (no system schemas).
         let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
-        excluded.extend(opts.exclude_schemas.clone());
+        // Only push literal (non-glob) patterns into the SQL != ALL() list.
+        // Glob patterns are applied in-memory below via schema_matches_any.
+        let literal_excludes: Vec<String> = opts
+            .exclude_schemas
+            .iter()
+            .filter(|p| !p.contains(['*', '?']))
+            .cloned()
+            .collect();
+        excluded.extend(literal_excludes);
 
         client
             .query(
@@ -147,7 +155,6 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         let oid: u32 = row.get::<_, i64>("oid") as u32;
         let schema: &str = row.get("nspname");
         let name: &str = row.get("relname");
-        let relkind: i8 = row.get::<_, i8>("relkind");
         let partition_key: Option<String> = row.get("partition_key");
         let partition_bound: Option<String> = row.get("partition_bound");
         let parent_table: Option<String> = row.get("parent_table");
@@ -165,8 +172,6 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         if super::filter::matches_any(&opts.exclude_tables, schema, name) {
             continue;
         }
-
-        let _ = relkind; // used implicitly via partition_key/partition_bound
 
         // Query columns for all tables — used both for DDL (regular/partitioned
         // parents) and for data dumping (partition children).

--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -154,9 +154,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         let parent_schema: Option<String> = row.get("parent_schema");
 
         // Schema inclusion filter (supports glob patterns).
-        if !opts.schemas.is_empty()
-            && !super::filter::schema_matches_any(&opts.schemas, schema)
-        {
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
             continue;
         }
         // Schema exclusion filter (supports glob patterns).

--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -153,13 +153,18 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         let parent_table: Option<String> = row.get("parent_table");
         let parent_schema: Option<String> = row.get("parent_schema");
 
-        // Schema inclusion filter.
-        if !opts.schemas.is_empty() && !opts.schemas.iter().any(|s| s == schema) {
+        // Schema inclusion filter (supports glob patterns).
+        if !opts.schemas.is_empty()
+            && !super::filter::schema_matches_any(&opts.schemas, schema)
+        {
             continue;
         }
-        // Table exclusion filter.
-        let fqn = format!("{schema}.{name}");
-        if opts.exclude_tables.iter().any(|t| *t == name || *t == fqn) {
+        // Schema exclusion filter (supports glob patterns).
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        // Table exclusion filter (supports glob patterns).
+        if super::filter::matches_any(&opts.exclude_tables, schema, name) {
             continue;
         }
 

--- a/src/dump/directory_format.rs
+++ b/src/dump/directory_format.rs
@@ -156,6 +156,12 @@ pub async fn dump_directory(opts: &DumpOptions, output_dir: &str) -> Result<()> 
         if opts.jobs <= 1 {
             // Sequential path — reuse the existing single connection.
             for (_, table, dat_file) in &data_entries {
+                // Skip data for tables matching --exclude-table-data patterns.
+                if super::filter::matches_any(&opts.exclude_table_data, &table.schema, &table.name)
+                {
+                    continue;
+                }
+
                 let dat_path = dir_path.join(dat_file);
                 let mut data_buf = String::new();
                 format::write_table_data(&mut data_buf, &client, table, opts).await?;
@@ -179,6 +185,15 @@ pub async fn dump_directory(opts: &DumpOptions, output_dir: &str) -> Result<()> 
             // Spawn one task per table; each acquires a semaphore permit.
             let mut join_handles = Vec::new();
             for (idx, table, dat_file) in tables_owned {
+                // Skip data for tables matching --exclude-table-data patterns.
+                if super::filter::matches_any(
+                    &opts_arc.exclude_table_data,
+                    &table.schema,
+                    &table.name,
+                ) {
+                    continue;
+                }
+
                 let sem = Arc::clone(&semaphore);
                 let conninfo = conninfo.clone();
                 let dir_path = dir_path_owned.clone();

--- a/src/dump/filter.rs
+++ b/src/dump/filter.rs
@@ -14,40 +14,28 @@
 /// Returns `true` if `text` matches the glob `pattern`.
 ///
 /// Supports `*` (any sequence) and `?` (any single character).
+/// Uses an O(m×n) DP algorithm to avoid exponential backtracking.
 pub fn glob_match(pattern: &str, text: &str) -> bool {
     let p: Vec<char> = pattern.chars().collect();
     let t: Vec<char> = text.chars().collect();
-    glob_match_inner(&p, &t)
-}
-
-fn glob_match_inner(p: &[char], t: &[char]) -> bool {
-    match (p.first(), t.first()) {
-        // Both exhausted — match.
-        (None, None) => true,
-        // Pattern exhausted but text remains — no match.
-        (None, Some(_)) => false,
-        // `*` — try skipping zero or more characters in text.
-        (Some('*'), _) => {
-            // Skip consecutive `*` in pattern.
-            let rest_p = &p[1..];
-            // Try matching rest of pattern against every suffix of t.
-            // Start with zero consumption (skip the `*`), then one char at a time.
-            for skip in 0..=t.len() {
-                if glob_match_inner(rest_p, &t[skip..]) {
-                    return true;
-                }
-            }
-            false
+    let (m, n) = (p.len(), t.len());
+    let mut dp = vec![vec![false; n + 1]; m + 1];
+    dp[0][0] = true;
+    for i in 1..=m {
+        if p[i - 1] == '*' {
+            dp[i][0] = dp[i - 1][0];
         }
-        // `?` matches any single character.
-        (Some('?'), Some(_)) => glob_match_inner(&p[1..], &t[1..]),
-        // `?` with no text remaining — no match.
-        (Some('?'), None) => false,
-        // Literal character match.
-        (Some(pc), Some(tc)) if pc == tc => glob_match_inner(&p[1..], &t[1..]),
-        // Literal mismatch.
-        _ => false,
     }
+    for i in 1..=m {
+        for j in 1..=n {
+            dp[i][j] = match p[i - 1] {
+                '*' => dp[i - 1][j] || dp[i][j - 1],
+                '?' => dp[i - 1][j - 1],
+                c => dp[i - 1][j - 1] && c == t[j - 1],
+            };
+        }
+    }
+    dp[m][n]
 }
 
 /// Returns `true` if `name` matches any of the given patterns.

--- a/src/dump/filter.rs
+++ b/src/dump/filter.rs
@@ -1,4 +1,134 @@
 // Copyright 2026 pg_plumbing contributors
 // SPDX-License-Identifier: MIT
 
-//! Schema and table filtering for pg_dump (-t, -T, -n, -N).
+//! Schema and table filtering for pg_dump (-t, -T, -n, -N, --exclude-table-data).
+//!
+//! Provides fnmatch-style wildcard pattern matching:
+//! - `*` matches any sequence of characters (including empty)
+//! - `?` matches any single character
+//! - Matching is case-sensitive
+//!
+//! Each pattern is tested against both the unqualified name and the
+//! schema-qualified name (e.g. `foo` and `public.foo`).
+
+/// Returns `true` if `text` matches the glob `pattern`.
+///
+/// Supports `*` (any sequence) and `?` (any single character).
+pub fn glob_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    glob_match_inner(&p, &t)
+}
+
+fn glob_match_inner(p: &[char], t: &[char]) -> bool {
+    match (p.first(), t.first()) {
+        // Both exhausted — match.
+        (None, None) => true,
+        // Pattern exhausted but text remains — no match.
+        (None, Some(_)) => false,
+        // `*` — try skipping zero or more characters in text.
+        (Some('*'), _) => {
+            // Skip consecutive `*` in pattern.
+            let rest_p = &p[1..];
+            // Try matching rest of pattern against every suffix of t.
+            // Start with zero consumption (skip the `*`), then one char at a time.
+            for skip in 0..=t.len() {
+                if glob_match_inner(rest_p, &t[skip..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        // `?` matches any single character.
+        (Some('?'), Some(_)) => glob_match_inner(&p[1..], &t[1..]),
+        // `?` with no text remaining — no match.
+        (Some('?'), None) => false,
+        // Literal character match.
+        (Some(pc), Some(tc)) if pc == tc => glob_match_inner(&p[1..], &t[1..]),
+        // Literal mismatch.
+        _ => false,
+    }
+}
+
+/// Returns `true` if `name` matches any of the given patterns.
+///
+/// Each pattern is tested against both the unqualified `name` and the
+/// fully-qualified `schema.name`.
+pub fn matches_any(patterns: &[String], schema: &str, name: &str) -> bool {
+    if patterns.is_empty() {
+        return false;
+    }
+    let qualified = format!("{schema}.{name}");
+    patterns
+        .iter()
+        .any(|p| glob_match(p, name) || glob_match(p, &qualified))
+}
+
+/// Returns `true` if `schema` matches any of the given schema patterns.
+pub fn schema_matches_any(patterns: &[String], schema: &str) -> bool {
+    if patterns.is_empty() {
+        return false;
+    }
+    patterns.iter().any(|p| glob_match(p, schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match() {
+        assert!(glob_match("foo", "foo"));
+        assert!(!glob_match("foo", "bar"));
+    }
+
+    #[test]
+    fn star_wildcard() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("*", ""));
+        assert!(glob_match("dump_*", "dump_test_simple"));
+        assert!(!glob_match("dump_*", "other_table"));
+        assert!(glob_match("*simple", "dump_test_simple"));
+        assert!(glob_match("dump_*_simple", "dump_test_simple"));
+    }
+
+    #[test]
+    fn question_wildcard() {
+        assert!(glob_match("fo?", "foo"));
+        assert!(glob_match("fo?", "fob"));
+        assert!(!glob_match("fo?", "fooo"));
+        assert!(!glob_match("fo?", "fo"));
+    }
+
+    #[test]
+    fn qualified_name_match() {
+        assert!(matches_any(
+            &["dump_test_simple".to_string()],
+            "public",
+            "dump_test_simple"
+        ));
+        assert!(matches_any(
+            &["public.dump_test_simple".to_string()],
+            "public",
+            "dump_test_simple"
+        ));
+        assert!(!matches_any(
+            &["other.dump_test_simple".to_string()],
+            "public",
+            "dump_test_simple"
+        ));
+    }
+
+    #[test]
+    fn schema_match() {
+        assert!(schema_matches_any(&["public".to_string()], "public"));
+        assert!(!schema_matches_any(&["other".to_string()], "public"));
+        assert!(schema_matches_any(&["pub*".to_string()], "public"));
+    }
+
+    #[test]
+    fn empty_patterns() {
+        assert!(!matches_any(&[], "public", "foo"));
+        assert!(!schema_matches_any(&[], "public"));
+    }
+}

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -204,20 +204,27 @@ pub async fn dump_custom(opts: &DumpOptions) -> Result<Vec<u8>> {
     let mut table_data: Vec<(TocEntry, Vec<u8>)> = Vec::new();
 
     if !opts.schema_only {
-        // Map table name → schema dump_id for dependencies.
+        // Map namespace.tag → schema dump_id for dependencies.
+        // Use qualified key to avoid collision when two schemas have same-named tables.
         let schema_id_map: std::collections::HashMap<String, i32> = schema_entries
             .iter()
-            .map(|e| (e.tag.clone(), e.dump_id))
+            .map(|e| (format!("{}.{}", e.namespace, e.tag), e.dump_id))
             .collect();
 
         for table in &tables {
+            // Skip data for tables matching --exclude-table-data patterns.
+            if filter::matches_any(&opts.exclude_table_data, &table.schema, &table.name) {
+                continue;
+            }
+
             let qname = table.qualified_name();
             let col_names: Vec<String> =
                 table.columns.iter().map(|c| quote_ident(&c.name)).collect();
             let col_list = col_names.join(", ");
             let copy_stmt = format!("COPY {qname} ({col_list}) FROM stdin;");
 
-            let deps = if let Some(&sid) = schema_id_map.get(&table.name) {
+            let qualified_key = format!("{}.{}", table.schema, table.name);
+            let deps = if let Some(&sid) = schema_id_map.get(&qualified_key) {
                 vec![sid]
             } else {
                 Vec::new()

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -35,6 +35,8 @@ pub struct DumpOptions {
     pub exclude_schemas: Vec<String>,
     /// Tables to exclude.
     pub exclude_tables: Vec<String>,
+    /// Tables whose data should be excluded (schema dumped, data skipped).
+    pub exclude_table_data: Vec<String>,
     /// Suppress ownership statements.
     pub no_owner: bool,
     /// Suppress privilege statements.
@@ -134,8 +136,16 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
         }
 
         if !opts.schema_only {
-            format::write_table_data(&mut out, &client, table, opts).await?;
-            out.push('\n');
+            // Skip data for tables matching --exclude-table-data patterns.
+            let skip_data = filter::matches_any(
+                &opts.exclude_table_data,
+                &table.schema,
+                &table.name,
+            );
+            if !skip_data {
+                format::write_table_data(&mut out, &client, table, opts).await?;
+                out.push('\n');
+            }
         }
     }
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -137,11 +137,8 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
 
         if !opts.schema_only {
             // Skip data for tables matching --exclude-table-data patterns.
-            let skip_data = filter::matches_any(
-                &opts.exclude_table_data,
-                &table.schema,
-                &table.name,
-            );
+            let skip_data =
+                filter::matches_any(&opts.exclude_table_data, &table.schema, &table.name);
             if !skip_data {
                 format::write_table_data(&mut out, &client, table, opts).await?;
                 out.push('\n');

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ pub struct PgDumpArgs {
     #[arg(short = 'T', long = "exclude-table")]
     exclude_table: Vec<String>,
 
+    /// Do not dump data for the named table(s) (schema is still dumped).
+    #[arg(long = "exclude-table-data")]
+    exclude_table_data: Vec<String>,
+
     /// Suppress output of ownership changes.
     #[arg(long = "no-owner")]
     no_owner: bool,
@@ -175,6 +179,7 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         schemas: args.schema,
         exclude_schemas: args.exclude_schema,
         exclude_tables: args.exclude_table,
+        exclude_table_data: args.exclude_table_data,
         no_owner: args.no_owner,
         no_privileges: args.no_privileges,
         jobs: args.jobs.unwrap_or(1).max(1),

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1331,6 +1331,11 @@ fn run_exclude_schema() {
         !stdout.contains("COPY public.dump_test_simple"),
         "output should NOT contain COPY for public tables:\n{stdout}"
     );
+    // Positive: the dump header should still be present (dump ran successfully).
+    assert!(
+        stdout.contains("PostgreSQL database dump"),
+        "output should contain the dump header:\n{stdout}"
+    );
 }
 
 #[test]
@@ -1357,6 +1362,11 @@ fn run_exclude_table() {
     assert!(
         !stdout.contains("COPY public.dump_test_simple"),
         "output should NOT contain excluded table's COPY:\n{stdout}"
+    );
+    // Positive: the dump header is present (a non-excluded item).
+    assert!(
+        stdout.contains("PostgreSQL database dump"),
+        "output should contain the dump header:\n{stdout}"
     );
 }
 

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1314,25 +1314,88 @@ fn run_defaults_parallel() {}
 fn run_defaults_tar_format() {}
 
 #[test]
-#[ignore]
-/// exclude_dump_test_schema: pg_dump --exclude-schema=dump_test.
-fn run_exclude_schema() {}
+/// exclude_dump_test_schema: pg_dump --exclude-schema=public.
+/// Verifies that no tables from the public schema appear in the output.
+fn run_exclude_schema() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--exclude-schema", "public"]);
+    assert_eq!(code, 0, "pg_dump --exclude-schema should succeed");
+    // Should not contain any CREATE TABLE for public-schema tables.
+    assert!(
+        !stdout.contains("CREATE TABLE public.dump_test_simple"),
+        "output should NOT contain public tables:\n{stdout}"
+    );
+    // Should not contain data for public-schema tables.
+    assert!(
+        !stdout.contains("COPY public.dump_test_simple"),
+        "output should NOT contain COPY for public tables:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore]
-/// exclude_test_table: pg_dump --exclude-table=dump_test.test_table.
-fn run_exclude_table() {}
+/// exclude_test_table: pg_dump --exclude-table=dump_test_simple.
+/// Verifies that the excluded table does not appear in the output.
+fn run_exclude_table() {
+    crate::common::setup_test_schema();
+    // Dump all of public, excluding dump_test_simple.
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&[
+        "-d",
+        "postgres",
+        "--schema",
+        "public",
+        "--exclude-table",
+        "dump_test_simple",
+    ]);
+    assert_eq!(code, 0, "pg_dump --exclude-table should succeed");
+    // The excluded table's CREATE TABLE should not be present.
+    assert!(
+        !stdout.contains("CREATE TABLE public.dump_test_simple"),
+        "output should NOT contain excluded table's CREATE TABLE:\n{stdout}"
+    );
+    // The excluded table's COPY should not be present.
+    assert!(
+        !stdout.contains("COPY public.dump_test_simple"),
+        "output should NOT contain excluded table's COPY:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore]
 /// exclude_measurement: pg_dump --exclude-table-and-children=dump_test.measurement.
+/// No measurement/partition table exists in the test schema — skipping.
 fn run_exclude_measurement() {}
 
 #[test]
-#[ignore]
 /// exclude_measurement_data / exclude_test_table_data:
-/// pg_dump --exclude-table-data / --exclude-table-data-and-children.
-fn run_exclude_table_data() {}
+/// pg_dump --exclude-table-data=dump_test_simple.
+/// The table's schema (CREATE TABLE) is dumped but its data (COPY) is not.
+fn run_exclude_table_data() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&[
+        "-d",
+        "postgres",
+        "-t",
+        "dump_test_simple",
+        "--exclude-table-data",
+        "dump_test_simple",
+    ]);
+    assert_eq!(code, 0, "pg_dump --exclude-table-data should succeed");
+    // Schema should still be present.
+    assert!(
+        stdout.contains("CREATE TABLE public.dump_test_simple"),
+        "output should contain CREATE TABLE for schema:\n{stdout}"
+    );
+    // Data should be absent.
+    assert!(
+        !stdout.contains("COPY public.dump_test_simple"),
+        "output should NOT contain COPY for excluded-data table:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("alice"),
+        "output should NOT contain row data:\n{stdout}"
+    );
+}
 
 #[test]
 /// inserts: pg_dump --data-only --inserts.
@@ -1450,18 +1513,58 @@ fn run_no_subscriptions() {}
 fn run_no_table_access_method() {}
 
 #[test]
-#[ignore]
-/// only_dump_test_schema: pg_dump --schema=dump_test.
-fn run_only_schema() {}
+/// only_dump_test_schema: pg_dump --schema=public.
+/// Verifies that only tables from the public schema appear in the output.
+fn run_only_schema() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--schema", "public"]);
+    assert_eq!(code, 0, "pg_dump --schema should succeed");
+    // Should contain public schema tables.
+    assert!(
+        stdout.contains("CREATE TABLE public.dump_test_simple"),
+        "output should contain public schema tables:\n{stdout}"
+    );
+    // Should contain the dump header.
+    assert!(
+        stdout.contains("PostgreSQL database dump"),
+        "output should contain dump header:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore]
-/// only_dump_test_table: pg_dump --table=dump_test.test_table.
-fn run_only_table() {}
+/// only_dump_test_table: pg_dump --table=dump_test_simple.
+/// Verifies that only the specified table is in the output.
+fn run_only_table() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--table", "dump_test_simple"]);
+    assert_eq!(code, 0, "pg_dump --table should succeed");
+    // Should contain the specified table.
+    assert!(
+        stdout.contains("CREATE TABLE public.dump_test_simple"),
+        "output should contain the specified table:\n{stdout}"
+    );
+    // Should contain the table's data.
+    assert!(
+        stdout.contains("COPY public.dump_test_simple"),
+        "output should contain COPY for the specified table:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("alice"),
+        "output should contain row data:\n{stdout}"
+    );
+    // Should NOT contain other tables from the database (spot-check one).
+    assert!(
+        !stdout.contains("CREATE TABLE public.dump_test_restore"),
+        "output should NOT contain other tables:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore]
 /// only_dump_measurement: pg_dump --table-and-children=dump_test.measurement.
+/// No measurement/partition table exists in the test schema — skipping.
 fn run_only_measurement() {}
 
 #[test]


### PR DESCRIPTION
Closes #24

## Goal
Implement object-level filtering flags for pg_dump (--table, --exclude-table, --schema, --exclude-schema, --exclude-table-data) with fnmatch-style wildcard pattern matching.

## What changed
- `src/dump/filter.rs`: new fnmatch-style pattern matcher (pure Rust, no new deps). Supports `*` (any sequence) and `?` (single char), case-sensitive. Matches against both unqualified name (`foo`) and schema-qualified name (`public.foo`).
- `src/dump/mod.rs`: added `exclude_table_data: Vec<String>` field to `DumpOptions`; filtering logic in `dump_plain` skips data for tables matching `--exclude-table-data` patterns
- `src/dump/catalog.rs`: upgraded schema/table filter logic in `get_tables` to use glob matching (was exact string match)
- `src/bin/pg_dump.rs`: wired `--exclude-table/-T`, `--schema/-n`, `--exclude-schema/-N`, `--exclude-table-data` CLI flags and propagated them into `DumpOptions`
- `src/main.rs`: added `--exclude-table-data` to `PgDumpArgs` and wired it into `DumpOptions`
- `tests/pg_dump/t002_pg_dump.rs`: unignored and implemented `run_exclude_table`, `run_exclude_schema`, `run_only_table`, `run_only_schema`, `run_exclude_table_data`; kept `run_exclude_measurement` and `run_only_measurement` as `#[ignore]` (no measurement/partition table in test schema)

## How to verify
```
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test run_exclude
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test run_only
```

## Test results
Before: 94 passed / 210 ignored
After: 99 passed / 205 ignored — 5 new tests green, 0 failures