### PR TITLE
fix: separate dbname (DDL) from conninfo (connection) in DumpOptions/RestoreOptions

### DIFF
--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -317,7 +317,8 @@ fn main() {
     let conninfo = pg_plumbing::build_conninfo_with_params(&dbname, &conn_params);
 
     let opts = dump::DumpOptions {
-        dbname: conninfo,
+        dbname: dbname.clone(),
+        conninfo,
         tables: cli.table.clone(),
         schema_only: cli.schema_only,
         data_only: cli.data_only,

--- a/src/bin/pg_restore.rs
+++ b/src/bin/pg_restore.rs
@@ -271,9 +271,7 @@ fn main() {
         user: cli.username.clone(),
         password: cli.password.clone(),
     };
-    // Resolve conninfo once; store the result as dbname so that the restore
-    // functions (which call build_conninfo internally) pass it through unchanged.
-    let dbname = pg_plumbing::build_conninfo_with_params(&raw_dbname, &conn_params);
+    let conninfo = pg_plumbing::build_conninfo_with_params(&raw_dbname, &conn_params);
 
     // Require a positional file.
     let filename = match cli.filenames.first() {
@@ -292,7 +290,8 @@ fn main() {
         .max(1);
 
     let opts = restore::RestoreOptions {
-        dbname,
+        dbname: raw_dbname.clone(),
+        conninfo,
         clean: cli.clean,
         if_exists: cli.if_exists,
         jobs,

--- a/src/dump/directory_format.rs
+++ b/src/dump/directory_format.rs
@@ -51,8 +51,7 @@ pub async fn dump_directory(opts: &DumpOptions, output_dir: &str) -> Result<()> 
     }
 
     // Connect to the database (for schema + sequential data path).
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 
@@ -175,7 +174,7 @@ pub async fn dump_directory(opts: &DumpOptions, output_dir: &str) -> Result<()> 
         } else {
             // Parallel path — spawn N tasks, each with its own DB connection.
             let jobs = opts.jobs;
-            let conninfo = crate::build_conninfo(&opts.dbname);
+            let conninfo = opts.conninfo.clone();
             let semaphore = Arc::new(Semaphore::new(jobs));
             let dir_path_owned = dir_path.to_path_buf();
             let opts_arc = Arc::new(opts.clone());

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -15,8 +15,10 @@ use tokio_postgres::NoTls;
 /// Options controlling what and how to dump.
 #[derive(Debug, Clone)]
 pub struct DumpOptions {
-    /// Database name or connection string.
+    /// Bare database name (used for DDL: CREATE DATABASE, \connect).
     pub dbname: String,
+    /// Full conninfo string (used for the actual connection).
+    pub conninfo: String,
     /// Tables to include (empty = all).
     pub tables: Vec<String>,
     /// Dump only the schema, no data.
@@ -53,8 +55,7 @@ pub struct DumpOptions {
 
 /// Dump a database in plain SQL format.
 pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 
@@ -204,8 +205,7 @@ pub async fn dump_custom(opts: &DumpOptions) -> Result<Vec<u8>> {
     use custom_format::{write_data_block, write_eof, write_header, write_toc_entry, TocEntry};
     use format::write_table_data_to_string;
 
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{bail, Result};
 use clap::{Parser, ValueEnum};
-use pg_plumbing::{dump, restore};
+use pg_plumbing::{build_conninfo, dump, restore};
 
 /// pg_dump/pg_restore rewritten in Rust.
 #[derive(Parser, Debug)]
@@ -168,8 +168,10 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         .or(args.database.as_deref())
         .unwrap_or("postgres");
 
+    let conninfo = build_conninfo(dbname);
     let opts = dump::DumpOptions {
         dbname: dbname.to_string(),
+        conninfo,
         tables: args.table,
         schema_only: args.schema_only,
         data_only: args.data_only,
@@ -234,8 +236,10 @@ async fn run_pg_restore(args: PgRestoreArgs) -> Result<()> {
         None => bail!("pg_restore: no input file specified"),
     };
 
+    let conninfo = build_conninfo(&dbname);
     let opts = restore::RestoreOptions {
-        dbname,
+        dbname: dbname.clone(),
+        conninfo,
         clean: args.clean,
         if_exists: args.if_exists,
         jobs: args.jobs.unwrap_or(1).max(1),

--- a/src/restore/mod.rs
+++ b/src/restore/mod.rs
@@ -18,8 +18,10 @@ use crate::dump::custom_format;
 /// Options controlling how to restore.
 #[derive(Debug, Clone)]
 pub struct RestoreOptions {
-    /// Target database name or connection string.
+    /// Bare target database name (for display/error messages).
     pub dbname: String,
+    /// Full conninfo string (used for the actual connection).
+    pub conninfo: String,
     /// Drop objects before recreating them.
     pub clean: bool,
     /// Use DROP ... IF EXISTS (only meaningful with clean).
@@ -143,8 +145,7 @@ pub async fn restore_directory(input_dir: &str, opts: &RestoreOptions) -> Result
     }
 
     // Connect to the database for DDL (always single-threaded).
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 
@@ -182,7 +183,7 @@ pub async fn restore_directory(input_dir: &str, opts: &RestoreOptions) -> Result
         let jobs = opts.jobs;
         let semaphore = Arc::new(Semaphore::new(jobs));
         let dir_path_owned = dir_path.to_path_buf();
-        let conninfo_owned = conninfo.clone();
+        let conninfo_owned = opts.conninfo.clone();
 
         let mut handles = Vec::new();
         for (qname, dat_file) in data_entries {
@@ -267,8 +268,7 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
         .collect();
 
     // ── Connect ────────────────────────────────────────────────────────────
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 
@@ -341,8 +341,7 @@ pub async fn restore_custom(data: &[u8], opts: &RestoreOptions) -> Result<()> {
 
 /// Restore a plain-format SQL dump to a database.
 pub async fn restore_plain(sql: &str, opts: &RestoreOptions) -> Result<()> {
-    let conninfo = crate::build_conninfo(&opts.dbname);
-    let (client, connection) = tokio_postgres::connect(&conninfo, NoTls)
+    let (client, connection) = tokio_postgres::connect(&opts.conninfo, NoTls)
         .await
         .with_context(|| format!("failed to connect to database \"{}\"", opts.dbname))?;
 

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1113,7 +1113,7 @@ fn run_column_inserts() {
 }
 
 #[test]
-/// createdb: pg_dump --create produces CREATE DATABASE.
+/// createdb: pg_dump --create produces CREATE DATABASE with bare db name, not conninfo.
 fn run_createdb() {
     crate::common::setup_test_schema();
     let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--create"]);
@@ -1125,6 +1125,20 @@ fn run_createdb() {
     assert!(
         stdout.contains("\\connect"),
         "output should contain \\connect:\n{stdout}"
+    );
+    // Regression guard for #34: dbname must be the bare name, not the full conninfo.
+    assert!(
+        stdout.contains("CREATE DATABASE \"postgres\""),
+        "CREATE DATABASE must use bare db name, not conninfo:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\\connect \"postgres\""),
+        "\\connect must use bare db name, not conninfo:\n{stdout}"
+    );
+    // Passwords must never appear in dump output.
+    assert!(
+        !stdout.contains("password="),
+        "dump output must not contain password:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## Goal
Fixes regression from #34 where `DumpOptions.dbname` was set to the full conninfo string instead of the bare database name.

## What Changed
- Added `conninfo: String` field to `DumpOptions` and `RestoreOptions`
- `dump_plain`/`dump_directory`/restore functions now use `opts.conninfo` for connection, `opts.dbname` for DDL
- `src/bin/pg_dump.rs` and `src/bin/pg_restore.rs` set both fields correctly (bare name for DDL, full conninfo for connection)
- `src/main.rs` (pg-dump/pg-restore subcommands) likewise updated
- Strengthened `run_createdb` test to assert exact bare name (`CREATE DATABASE "postgres"`) and absence of `password=` in dump output

## How to Verify
```bash
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test
```
All tests pass, 0 failed.