### PR TITLE
feat: emit sequences, views, and ownership DDL in dump output

### DIFF
--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -15,6 +15,8 @@ pub struct TableInfo {
     pub schema: String,
     /// Table name.
     pub name: String,
+    /// Owner role name.
+    pub owner: String,
     /// Columns in ordinal order.
     pub columns: Vec<ColumnInfo>,
     /// Primary key constraint, if any.
@@ -68,6 +70,67 @@ impl TableInfo {
     }
 }
 
+/// Metadata for a single sequence.
+#[derive(Debug, Clone)]
+pub struct SequenceInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Sequence name.
+    pub name: String,
+    /// Start value.
+    pub start_value: i64,
+    /// Increment.
+    pub increment_by: i64,
+    /// Minimum value.
+    pub min_value: i64,
+    /// Maximum value.
+    pub max_value: i64,
+    /// Cache size.
+    pub cache_size: i64,
+    /// Whether the sequence cycles.
+    pub cycle: bool,
+    /// OWNED BY table schema (if owned by a column).
+    pub owned_by_schema: Option<String>,
+    /// OWNED BY table name (if owned by a column).
+    pub owned_by_table: Option<String>,
+    /// OWNED BY column name (if owned by a column).
+    pub owned_by_column: Option<String>,
+}
+
+impl SequenceInfo {
+    /// Fully qualified name: `schema.name`.
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for a single view.
+#[derive(Debug, Clone)]
+pub struct ViewInfo {
+    /// Schema name.
+    pub schema: String,
+    /// View name.
+    pub name: String,
+    /// View definition from `pg_get_viewdef`.
+    pub definition: String,
+}
+
+impl ViewInfo {
+    /// Fully qualified name: `schema.name`.
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for a single schema.
+#[derive(Debug, Clone)]
+pub struct SchemaInfo {
+    /// Schema name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+}
+
 /// Query the catalog for tables matching the dump options.
 ///
 /// Returns both regular tables (`relkind = 'r'`) and partitioned tables
@@ -91,6 +154,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                 "select c.oid::int8 as oid,
                         n.nspname,
                         c.relname,
+                        r.rolname as owner,
                         c.relkind,
                         pg_catalog.pg_get_partkeydef(c.oid) as partition_key,
                         pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_bound,
@@ -107,6 +171,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                          LIMIT 1) AS parent_schema
                  from pg_catalog.pg_class c
                  join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                 join pg_catalog.pg_roles r on r.oid = c.relowner
                  where c.relkind in ('r', 'p')
                    and n.nspname != all($1)
                  order by
@@ -128,6 +193,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                     "select c.oid::int8 as oid,
                             n.nspname,
                             c.relname,
+                            r.rolname as owner,
                             c.relkind,
                             pg_catalog.pg_get_partkeydef(c.oid) as partition_key,
                             pg_catalog.pg_get_expr(c.relpartbound, c.oid) as partition_bound,
@@ -145,6 +211,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                      from pg_catalog.pg_class c
                      join pg_catalog.pg_namespace n
                        on n.oid = c.relnamespace
+                     join pg_catalog.pg_roles r on r.oid = c.relowner
                      where c.relkind in ('r', 'p')
                        and n.nspname = $1
                        and c.relname = $2
@@ -164,6 +231,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         let oid: u32 = row.get::<_, i64>("oid") as u32;
         let schema: &str = row.get("nspname");
         let name: &str = row.get("relname");
+        let owner: &str = row.get("owner");
         let partition_key: Option<String> = row.get("partition_key");
         let partition_bound: Option<String> = row.get("partition_bound");
         let parent_table: Option<String> = row.get("parent_table");
@@ -192,6 +260,7 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         tables.push(TableInfo {
             schema: schema.to_string(),
             name: name.to_string(),
+            owner: owner.to_string(),
             columns,
             primary_key,
             constraints,
@@ -203,6 +272,173 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
     }
 
     Ok(tables)
+}
+
+/// Query user-visible schemas (excludes system schemas) with their owners.
+pub async fn get_schemas(client: &Client, opts: &DumpOptions) -> Result<Vec<SchemaInfo>> {
+    let rows = client
+        .query(
+            "SELECT n.nspname, r.rolname AS owner
+             FROM pg_catalog.pg_namespace n
+             JOIN pg_catalog.pg_roles r ON r.oid = n.nspowner
+             WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+               AND n.nspname NOT LIKE 'pg_temp_%'
+               AND n.nspname NOT LIKE 'pg_toast_temp_%'
+             ORDER BY n.nspname",
+            &[],
+        )
+        .await
+        .context("query schemas")?;
+
+    let mut schemas = Vec::new();
+    for row in &rows {
+        let name: &str = row.get("nspname");
+        let owner: &str = row.get("owner");
+
+        // Apply schema inclusion/exclusion filters.
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, name) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, name) {
+            continue;
+        }
+
+        schemas.push(SchemaInfo {
+            name: name.to_string(),
+            owner: owner.to_string(),
+        });
+    }
+    Ok(schemas)
+}
+
+/// Query the catalog for sequences matching the dump options.
+///
+/// Returns sequences from non-system schemas, ordered by schema then name.
+/// Each sequence includes OWNED BY information (table/column) if applicable.
+pub async fn get_sequences(client: &Client, opts: &DumpOptions) -> Result<Vec<SequenceInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname AS schema_name,
+                    s.relname AS seq_name,
+                    seq.seqstart AS start_value,
+                    seq.seqincrement AS increment_by,
+                    seq.seqmin AS min_value,
+                    seq.seqmax AS max_value,
+                    seq.seqcache AS cache_size,
+                    seq.seqcycle AS cycle,
+                    t.relname AS owned_by_table,
+                    tn.nspname AS owned_by_schema,
+                    a.attname AS owned_by_column
+             FROM pg_catalog.pg_class s
+             JOIN pg_catalog.pg_namespace n ON n.oid = s.relnamespace
+             JOIN pg_catalog.pg_sequence seq ON seq.seqrelid = s.oid
+             LEFT JOIN pg_catalog.pg_depend d
+               ON d.objid = s.oid
+              AND d.classid = 'pg_catalog.pg_class'::regclass
+              AND d.refclassid = 'pg_catalog.pg_class'::regclass
+              AND d.deptype = 'a'
+             LEFT JOIN pg_catalog.pg_class t ON t.oid = d.refobjid
+             LEFT JOIN pg_catalog.pg_namespace tn ON tn.oid = t.relnamespace
+             LEFT JOIN pg_catalog.pg_attribute a
+               ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+             WHERE s.relkind = 'S'
+               AND n.nspname != all($1)
+             ORDER BY n.nspname, s.relname",
+            &[&excluded],
+        )
+        .await
+        .context("query sequences")?;
+
+    let mut sequences = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("schema_name");
+
+        // Schema inclusion filter (supports glob patterns).
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        // Schema exclusion filter (supports glob patterns).
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+
+        sequences.push(SequenceInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("seq_name").to_string(),
+            start_value: row.get("start_value"),
+            increment_by: row.get("increment_by"),
+            min_value: row.get("min_value"),
+            max_value: row.get("max_value"),
+            cache_size: row.get("cache_size"),
+            cycle: row.get("cycle"),
+            owned_by_schema: row.get("owned_by_schema"),
+            owned_by_table: row.get("owned_by_table"),
+            owned_by_column: row.get("owned_by_column"),
+        });
+    }
+
+    Ok(sequences)
+}
+
+/// Query the catalog for views matching the dump options.
+///
+/// Returns views from non-system schemas, ordered by schema then name.
+pub async fn get_views(client: &Client, opts: &DumpOptions) -> Result<Vec<ViewInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname AS schema_name,
+                    c.relname AS view_name,
+                    pg_catalog.pg_get_viewdef(c.oid, true) AS definition
+             FROM pg_catalog.pg_class c
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+             WHERE c.relkind = 'v'
+               AND n.nspname != all($1)
+             ORDER BY n.nspname, c.relname",
+            &[&excluded],
+        )
+        .await
+        .context("query views")?;
+
+    let mut views = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("schema_name");
+
+        // Schema inclusion filter (supports glob patterns).
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        // Schema exclusion filter (supports glob patterns).
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+
+        let definition: Option<String> = row.get("definition");
+        views.push(ViewInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("view_name").to_string(),
+            definition: definition.unwrap_or_default(),
+        });
+    }
+
+    Ok(views)
 }
 
 /// Parse a potentially qualified table name into (schema, name).

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use tokio_postgres::Client;
 
-use super::catalog::{quote_ident, ConstraintInfo, TableInfo};
+use super::catalog::{quote_ident, ConstraintInfo, SchemaInfo, SequenceInfo, TableInfo, ViewInfo};
 use super::DumpOptions;
 
 /// Write a `CREATE TABLE` statement to the output buffer, followed by any
@@ -122,6 +122,86 @@ pub fn write_create_table(out: &mut String, table: &TableInfo) {
             con.definition
         ));
     }
+}
+
+/// Write a `CREATE SEQUENCE` statement to the output buffer.
+pub fn write_create_sequence(out: &mut String, seq: &SequenceInfo) {
+    let qname = seq.qualified_name();
+    out.push_str(&format!(
+        "--\n-- Name: {}; Type: SEQUENCE\n--\n\n",
+        seq.name
+    ));
+    out.push_str(&format!("CREATE SEQUENCE {qname}\n"));
+    out.push_str(&format!("    START WITH {}\n", seq.start_value));
+    out.push_str(&format!("    INCREMENT BY {}\n", seq.increment_by));
+    out.push_str(&format!("    MINVALUE {}\n", seq.min_value));
+    out.push_str(&format!("    MAXVALUE {}\n", seq.max_value));
+    if seq.cycle {
+        out.push_str("    CYCLE\n");
+    } else {
+        out.push_str("    NO CYCLE\n");
+    }
+    out.push_str(&format!("    CACHE {};\n", seq.cache_size));
+}
+
+/// Write `ALTER SEQUENCE … OWNED BY` statement if the sequence has an owner.
+pub fn write_alter_sequence(out: &mut String, seq: &SequenceInfo) {
+    if let (Some(ref owned_schema), Some(ref owned_table), Some(ref owned_col)) = (
+        &seq.owned_by_schema,
+        &seq.owned_by_table,
+        &seq.owned_by_column,
+    ) {
+        let qname = seq.qualified_name();
+        let owned_col_q = quote_ident(owned_col);
+        out.push_str(&format!(
+            "\n--\n-- Name: {}; Type: SEQUENCE OWNED BY\n--\n\nALTER SEQUENCE {qname} OWNED BY {}.{}.{owned_col_q};\n",
+            seq.name,
+            quote_ident(owned_schema),
+            quote_ident(owned_table),
+        ));
+    }
+}
+
+/// Write a `CREATE OR REPLACE VIEW` statement to the output buffer.
+pub fn write_create_view(out: &mut String, view: &ViewInfo) {
+    let qname = view.qualified_name();
+    out.push_str(&format!(
+        "--\n-- Name: {}; Type: VIEW\n--\n\n",
+        view.name
+    ));
+    out.push_str(&format!("CREATE OR REPLACE VIEW {qname} AS\n"));
+    let def = view.definition.trim_end();
+    out.push_str(def);
+    if !def.ends_with(';') {
+        out.push(';');
+    }
+    out.push('\n');
+}
+
+/// Write an `ALTER TABLE [ONLY] … OWNER TO …;` statement.
+///
+/// Uses `ONLY` for regular tables; omits it for partitioned tables and
+/// partition children (matching real pg_dump behaviour).
+pub fn write_alter_table_owner(out: &mut String, table: &TableInfo) {
+    let qname = table.qualified_name();
+    let only = if table.partition_key.is_none() && table.partition_bound.is_none() {
+        "ONLY "
+    } else {
+        ""
+    };
+    out.push_str(&format!(
+        "ALTER TABLE {only}{qname} OWNER TO {};\n",
+        quote_ident(&table.owner)
+    ));
+}
+
+/// Write an `ALTER SCHEMA … OWNER TO …;` statement.
+pub fn write_alter_schema_owner(out: &mut String, schema: &SchemaInfo) {
+    out.push_str(&format!(
+        "ALTER SCHEMA {} OWNER TO {};\n",
+        quote_ident(&schema.name),
+        quote_ident(&schema.owner)
+    ));
 }
 
 /// Write table data as a raw COPY data string (rows only, no header/footer).

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -165,10 +165,7 @@ pub fn write_alter_sequence(out: &mut String, seq: &SequenceInfo) {
 /// Write a `CREATE OR REPLACE VIEW` statement to the output buffer.
 pub fn write_create_view(out: &mut String, view: &ViewInfo) {
     let qname = view.qualified_name();
-    out.push_str(&format!(
-        "--\n-- Name: {}; Type: VIEW\n--\n\n",
-        view.name
-    ));
+    out.push_str(&format!("--\n-- Name: {}; Type: VIEW\n--\n\n", view.name));
     out.push_str(&format!("CREATE OR REPLACE VIEW {qname} AS\n"));
     let def = view.definition.trim_end();
     out.push_str(def);

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -68,6 +68,15 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     let tables = catalog::get_tables(&client, opts)
         .await
         .context("failed to query catalog")?;
+    let sequences = catalog::get_sequences(&client, opts)
+        .await
+        .context("failed to query sequences")?;
+    let views = catalog::get_views(&client, opts)
+        .await
+        .context("failed to query views")?;
+    let schemas = catalog::get_schemas(&client, opts)
+        .await
+        .context("failed to query schemas")?;
 
     let mut out = String::new();
 
@@ -121,6 +130,61 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     out.push_str("SET client_min_messages = warning;\n");
     out.push_str("SET row_security = off;\n\n");
 
+    // When a table filter is active (-t), we only want objects directly tied
+    // to the selected tables.  Views and schema OWNER TO statements reference
+    // objects that may not exist in the restore target, so we skip them.
+    // Sequences are only emitted when owned by one of the selected tables.
+    let table_filter_active = !opts.tables.is_empty();
+
+    // Set of table names actually being dumped — used to filter sequences.
+    let dumped_table_names: std::collections::HashSet<&str> =
+        tables.iter().map(|t| t.name.as_str()).collect();
+
+    // Compute schemas that have at least one table being dumped.
+    let dumped_schema_names: std::collections::HashSet<&str> =
+        tables.iter().map(|t| t.schema.as_str()).collect();
+
+    if !opts.data_only {
+        for seq in &sequences {
+            if table_filter_active {
+                // In table-filter mode, only emit sequences owned by a
+                // selected table.  Standalone sequences and sequences owned
+                // by other tables are skipped.
+                match &seq.owned_by_table {
+                    Some(t) if dumped_table_names.contains(t.as_str()) => {}
+                    _ => continue,
+                }
+            } else {
+                // Full-DB or schema-filter dump: skip sequences from schemas
+                // not represented in this dump.
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(seq.schema.as_str())
+                {
+                    continue;
+                }
+            }
+            format::write_create_sequence(&mut out, seq);
+            out.push('\n');
+            format::write_alter_sequence(&mut out, seq);
+        }
+
+        // Emit ALTER SCHEMA ... OWNER TO only for full-DB or schema-filtered
+        // dumps.  A table-specific dump (-t) must not emit schema ownership
+        // because the schema may not exist in the restore target.
+        if !table_filter_active {
+            let mut emitted_schema = false;
+            for schema in &schemas {
+                if dumped_schema_names.contains(schema.name.as_str()) {
+                    format::write_alter_schema_owner(&mut out, schema);
+                    emitted_schema = true;
+                }
+            }
+            if emitted_schema {
+                out.push('\n');
+            }
+        }
+    }
+
     for table in &tables {
         if !opts.data_only {
             // --clean: emit DROP statement before each CREATE TABLE
@@ -133,6 +197,7 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
                 }
             }
             format::write_create_table(&mut out, table);
+            format::write_alter_table_owner(&mut out, table);
             out.push('\n');
         }
 
@@ -144,6 +209,20 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
                 format::write_table_data(&mut out, &client, table, opts).await?;
                 out.push('\n');
             }
+        }
+    }
+
+    if !opts.data_only && !table_filter_active {
+        // Skip views entirely in table-filter mode: a view may reference
+        // tables that are not included in the dump, causing restore failures.
+        for view in &views {
+            if !dumped_schema_names.is_empty()
+                && !dumped_schema_names.contains(view.schema.as_str())
+            {
+                continue;
+            }
+            format::write_create_view(&mut out, view);
+            out.push('\n');
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -218,6 +218,30 @@ pub fn drop_test_db(dbname: &str) {
     let _ = cmd.output();
 }
 
+/// Set up the view test schema. Requires setup_test_schema() to have run first.
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_view_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+        let sql = "CREATE OR REPLACE VIEW dump_test_view AS \
+                   SELECT id, name FROM dump_test_simple;";
+        let mut cmd = Command::new("psql");
+        cmd.arg(&conninfo).arg("-c").arg(sql);
+        if !password.is_empty() {
+            cmd.env("PGPASSWORD", &password);
+        }
+        let output = cmd.output().expect("psql setup_view failed");
+        assert!(
+            output.status.success(),
+            "setup_view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    });
+}
+
 /// Set up the parallel-dump test schema (partitioned tables + enum type).
 /// Uses OnceLock to avoid poisoning.
 pub fn setup_parallel_test_schema() {

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -117,23 +117,51 @@ fn alter_schema_owner() {}
 fn alter_schema_second_owner() {}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
+
 /// ALTER SCHEMA public OWNER TO.
-fn alter_schema_public_owner() {}
+fn alter_schema_public_owner() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER SCHEMA public OWNER TO"),
+        "output should contain ALTER SCHEMA public OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
+
 /// ALTER SCHEMA public OWNER TO (without ACL changes).
-fn alter_schema_public_owner_no_acl() {}
+fn alter_schema_public_owner_no_acl() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--no-acl"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER SCHEMA public OWNER TO"),
+        "output should contain ALTER SCHEMA public OWNER TO with --no-acl:\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: ALTER TABLE / SEQUENCE / INDEX
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: ALTER SEQUENCE not emitted in dump output
+
 /// ALTER SEQUENCE test_table_col1_seq is dumped correctly.
-fn alter_sequence() {}
+fn alter_sequence() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER SEQUENCE"),
+        "output should contain ALTER SEQUENCE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dump_test_simple_id_seq"),
+        "ALTER SEQUENCE should reference dump_test_simple_id_seq:\n{stdout}"
+    );
+}
 
 #[test]
 /// ALTER TABLE ONLY test_table ADD CONSTRAINT ... PRIMARY KEY.
@@ -208,9 +236,17 @@ fn alter_table_owner() {}
 fn alter_table_enable_rls() {}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
+
 /// ALTER TABLE test_second_table OWNER TO.
-fn alter_second_table_owner() {}
+fn alter_second_table_owner() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER TABLE ONLY public.dump_test_simple OWNER TO"),
+        "output should contain ALTER TABLE ONLY public.dump_test_simple OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: OWNER TO not emitted in dump output
@@ -874,9 +910,21 @@ fn statistics_import() {}
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: CREATE SEQUENCE not emitted separately
+
 /// CREATE SEQUENCE test_table_col1_seq.
-fn create_sequence() {}
+fn create_sequence() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE SEQUENCE"),
+        "output should contain CREATE SEQUENCE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dump_test_simple_id_seq"),
+        "CREATE SEQUENCE should reference dump_test_simple_id_seq:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs partitioned measurement table + index setup
@@ -894,9 +942,22 @@ fn alter_measurement_primary_key() {}
 fn alter_index_attach_partition() {}
 
 #[test]
-#[ignore] // not yet implemented: CREATE VIEW not emitted in dump output
+
 /// CREATE VIEW test_view / ALTER VIEW test_view SET DEFAULT.
-fn create_view() {}
+fn create_view() {
+    crate::common::setup_test_schema();
+    crate::common::setup_view_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE VIEW") || stdout.contains("CREATE OR REPLACE VIEW"),
+        "output should contain CREATE VIEW:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dump_test_view"),
+        "CREATE VIEW should reference dump_test_view:\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: DROP statements (--clean output)


### PR DESCRIPTION
## Goal
Emit CREATE SEQUENCE, ALTER SEQUENCE, CREATE VIEW, and ALTER TABLE/SCHEMA OWNER TO statements in pg_dump plain output, enabling multiple previously-ignored t002 tests.

## What changed
- `src/dump/catalog.rs`: Added SequenceInfo, ViewInfo, SchemaInfo + corresponding get_*() functions
- `src/dump/format.rs`: Added write_create_sequence(), write_alter_sequence(), write_create_view(), write_alter_table_owner(), write_alter_schema_owner()
- `src/dump/mod.rs`: dump_plain() emits sequences, views, ownership DDL; filtered correctly for table-specific dumps (views/schema-owners skipped when -t is active; sequences filtered to only those owned by selected tables)
- `tests/pg_dump/t002_pg_dump.rs`: Removed #[ignore] from create_sequence, alter_sequence, create_view, and owner tests
- `tests/common/mod.rs`: Added setup_view_schema() helper

## How to verify
```
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test 2>&1 | grep 'passed\|failed\|ignored'
```
0 failures.

## Closes
Closes #42, closes #45