### PR TITLE
feat: emit COMMENT ON for tables, columns, and schemas in dump output

### DIFF
--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -525,6 +525,87 @@ pub async fn get_constraints(client: &Client, table_oid: u32) -> Result<Vec<Cons
     Ok(constraints)
 }
 
+/// Metadata for a single comment.
+#[derive(Debug, Clone)]
+pub struct CommentInfo {
+    /// The SQL object type (TABLE, COLUMN, SCHEMA, etc.)
+    pub object_type: String,
+    /// Fully qualified object name.
+    pub object_name: String,
+    /// The comment text.
+    pub comment: String,
+}
+
+/// Query comments from pg_description and pg_shdescription.
+pub async fn get_comments(client: &Client, _opts: &DumpOptions) -> Result<Vec<CommentInfo>> {
+    let mut comments = Vec::new();
+
+    // Table and column comments from pg_description.
+    let rows = client
+        .query(
+            "SELECT
+                CASE
+                    WHEN a.attnum IS NULL THEN 'TABLE'
+                    ELSE 'COLUMN'
+                END AS object_type,
+                CASE
+                    WHEN a.attnum IS NULL THEN
+                        format('%I.%I', n.nspname, c.relname)
+                    ELSE
+                        format('%I.%I.%I', n.nspname, c.relname, a.attname)
+                END AS object_name,
+                d.description
+             FROM pg_catalog.pg_description d
+             JOIN pg_catalog.pg_class c ON c.oid = d.objoid
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+             LEFT JOIN pg_catalog.pg_attribute a
+               ON a.attrelid = d.objoid AND a.attnum = d.objsubid
+             WHERE c.relkind IN ('r', 'p', 'v')
+               AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+               AND d.classoid = 'pg_catalog.pg_class'::regclass
+             ORDER BY n.nspname, c.relname, d.objsubid",
+            &[],
+        )
+        .await
+        .context("query table/column comments")?;
+
+    for row in &rows {
+        let object_type: &str = row.get("object_type");
+        let object_name: &str = row.get("object_name");
+        let comment: &str = row.get("description");
+        comments.push(CommentInfo {
+            object_type: object_type.to_string(),
+            object_name: object_name.to_string(),
+            comment: comment.to_string(),
+        });
+    }
+
+    // Schema comments from pg_description.
+    let schema_rows = client
+        .query(
+            "SELECT n.nspname, d.description
+             FROM pg_catalog.pg_description d
+             JOIN pg_catalog.pg_namespace n ON n.oid = d.objoid
+             WHERE d.classoid = 'pg_catalog.pg_namespace'::regclass
+             ORDER BY n.nspname",
+            &[],
+        )
+        .await
+        .context("query schema comments")?;
+
+    for row in &schema_rows {
+        let nspname: &str = row.get("nspname");
+        let description: &str = row.get("description");
+        comments.push(CommentInfo {
+            object_type: "SCHEMA".to_string(),
+            object_name: quote_ident(nspname),
+            comment: description.to_string(),
+        });
+    }
+
+    Ok(comments)
+}
+
 /// Quote an SQL identifier if it needs quoting.
 pub fn quote_ident(name: &str) -> String {
     // Simple heuristic: quote if not all lowercase alphanumeric/underscore,

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -201,6 +201,17 @@ pub fn write_alter_schema_owner(out: &mut String, schema: &SchemaInfo) {
     ));
 }
 
+/// Write `COMMENT ON …` statements.
+pub fn write_comments(out: &mut String, comments: &[super::catalog::CommentInfo]) {
+    for c in comments {
+        let escaped = c.comment.replace('\'', "''");
+        out.push_str(&format!(
+            "COMMENT ON {} {} IS '{}';\n",
+            c.object_type, c.object_name, escaped
+        ));
+    }
+}
+
 /// Write table data as a raw COPY data string (rows only, no header/footer).
 ///
 /// Returns just the tab-separated rows suitable for embedding in a custom archive.

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -226,6 +226,17 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
         }
     }
 
+    // Emit COMMENT ON statements.
+    if !opts.data_only && !table_filter_active {
+        let comments = catalog::get_comments(&client, opts)
+            .await
+            .context("failed to query comments")?;
+        if !comments.is_empty() {
+            format::write_comments(&mut out, &comments);
+            out.push('\n');
+        }
+    }
+
     out.push_str("--\n");
     out.push_str("-- PostgreSQL database dump complete\n");
     out.push_str("--\n\n");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -81,6 +81,9 @@ pub fn setup_test_schema() {
                 ('alice', 1),\n\
                 ('bob', 2),\n\
                 ('charlie', 3);\n\
+            COMMENT ON TABLE dump_test_simple IS 'test table for pg_plumbing';\n\
+            COMMENT ON COLUMN dump_test_simple.name IS 'person name column';\n\
+            COMMENT ON SCHEMA public IS 'standard public schema';\n\
         ";
         let mut cmd = Command::new("psql");
         cmd.arg(&conninfo).arg("-c").arg(sql);

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -307,19 +307,44 @@ fn comment_on_database() {}
 fn comment_on_extension() {}
 
 #[test]
-#[ignore] // not yet implemented: COMMENT ON not emitted in dump output
 /// COMMENT ON SCHEMA public / COMMENT ON SCHEMA public IS NULL.
-fn comment_on_schema_public() {}
+fn comment_on_schema_public() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COMMENT ON SCHEMA public"),
+        "output should contain COMMENT ON SCHEMA public:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: COMMENT ON not emitted in dump output
 /// COMMENT ON TABLE dump_test.test_table.
-fn comment_on_table() {}
+fn comment_on_table() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COMMENT ON TABLE"),
+        "output should contain COMMENT ON TABLE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dump_test_simple"),
+        "COMMENT ON TABLE should reference dump_test_simple:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: COMMENT ON not emitted in dump output
 /// COMMENT ON COLUMN dump_test.test_table.col1.
-fn comment_on_column() {}
+fn comment_on_column() {
+    crate::common::setup_test_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COMMENT ON COLUMN"),
+        "output should contain COMMENT ON COLUMN:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: COMMENT ON not emitted in dump output


### PR DESCRIPTION
## Goal
Emit COMMENT ON TABLE, COLUMN, and SCHEMA statements in pg_dump output, enabling previously-ignored t002 tests.

## What changed
- `src/dump/catalog.rs`: Added `CommentInfo` + `get_comments()` querying `pg_description` for table/column/schema comments
- `src/dump/format.rs`: Added `write_comments()`
- `src/dump/mod.rs`: `dump_plain()` emits comments after views; skipped in table-filter mode
- `tests/common/mod.rs`: `setup_test_schema()` now adds COMMENT ON TABLE/COLUMN/SCHEMA
- `tests/pg_dump/t002_pg_dump.rs`: Implemented `comment_on_table`, `comment_on_column`, `comment_on_schema_public`; removed `#[ignore]`

## How to verify
```
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test -- comment_on_table comment_on_column comment_on_schema_public
```
All 3 tests green. Full suite: 131 passed, 0 failed.

## Closes
Closes #43