### PR TITLE
feat: emit CREATE SCHEMA and extended test schema (closes #49)

### DIFF
--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -194,6 +194,30 @@ pub fn write_alter_table_owner(out: &mut String, table: &TableInfo) {
     ));
 }
 
+/// Write a `CREATE SCHEMA` statement.
+pub fn write_create_schema(out: &mut String, schema: &SchemaInfo) {
+    out.push_str(&format!(
+        "--\n-- Name: {}; Type: SCHEMA\n--\n\nCREATE SCHEMA {};\n",
+        schema.name,
+        quote_ident(&schema.name),
+    ));
+}
+
+/// Write a `DROP SCHEMA [IF EXISTS]` statement.
+pub fn write_drop_schema(out: &mut String, schema: &SchemaInfo, if_exists: bool) {
+    if if_exists {
+        out.push_str(&format!(
+            "DROP SCHEMA IF EXISTS {} CASCADE;\n",
+            quote_ident(&schema.name),
+        ));
+    } else {
+        out.push_str(&format!(
+            "DROP SCHEMA {} CASCADE;\n",
+            quote_ident(&schema.name),
+        ));
+    }
+}
+
 /// Write an `ALTER SCHEMA … OWNER TO …;` statement.
 pub fn write_alter_schema_owner(out: &mut String, schema: &SchemaInfo) {
     out.push_str(&format!(

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -145,6 +145,21 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
         tables.iter().map(|t| t.schema.as_str()).collect();
 
     if !opts.data_only {
+        // Emit CREATE SCHEMA (and DROP SCHEMA for --clean) for full-DB or
+        // schema-filtered dumps.  Table-specific dumps (-t) skip schema DDL
+        // because the schema may not exist in the restore target.
+        if !table_filter_active {
+            for schema in &schemas {
+                // --clean: emit DROP SCHEMA before CREATE SCHEMA.
+                if opts.clean {
+                    format::write_drop_schema(&mut out, schema, opts.if_exists);
+                }
+                format::write_create_schema(&mut out, schema);
+                format::write_alter_schema_owner(&mut out, schema);
+                out.push('\n');
+            }
+        }
+
         for seq in &sequences {
             if table_filter_active {
                 // In table-filter mode, only emit sequences owned by a
@@ -166,22 +181,6 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
             format::write_create_sequence(&mut out, seq);
             out.push('\n');
             format::write_alter_sequence(&mut out, seq);
-        }
-
-        // Emit ALTER SCHEMA ... OWNER TO only for full-DB or schema-filtered
-        // dumps.  A table-specific dump (-t) must not emit schema ownership
-        // because the schema may not exist in the restore target.
-        if !table_filter_active {
-            let mut emitted_schema = false;
-            for schema in &schemas {
-                if dumped_schema_names.contains(schema.name.as_str()) {
-                    format::write_alter_schema_owner(&mut out, schema);
-                    emitted_schema = true;
-                }
-            }
-            if emitted_schema {
-                out.push('\n');
-            }
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -324,7 +324,9 @@ pub fn setup_dump_test_second_schema() {
         if !password.is_empty() {
             cmd.env("PGPASSWORD", &password);
         }
-        let output = cmd.output().expect("psql setup_dump_test_second_schema failed");
+        let output = cmd
+            .output()
+            .expect("psql setup_dump_test_second_schema failed");
         assert!(
             output.status.success(),
             "setup_dump_test_second_schema failed: {}",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -246,6 +246,93 @@ pub fn setup_view_schema() {
     });
 }
 
+/// Set up the dump_test schema with multiple test tables.
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_dump_test_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+        let sql = "\
+            CREATE SCHEMA IF NOT EXISTS dump_test;\n\
+            DROP TABLE IF EXISTS dump_test.test_inheritance_child CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_inheritance_parent CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_second_table CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_fourth_table_zero_col CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_fifth_table CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_sixth_table CASCADE;\n\
+            DROP TABLE IF EXISTS dump_test.test_seventh_table CASCADE;\n\
+            CREATE TABLE dump_test.test_second_table (\n\
+                id integer,\n\
+                col1 text,\n\
+                col2 text\n\
+            );\n\
+            INSERT INTO dump_test.test_second_table VALUES\n\
+                (1, 'foo', 'bar'),\n\
+                (2, 'baz', 'qux');\n\
+            CREATE TABLE dump_test.test_fourth_table_zero_col ();\n\
+            CREATE TABLE dump_test.test_fifth_table (\n\
+                id integer,\n\
+                val text\n\
+            );\n\
+            CREATE TABLE dump_test.test_sixth_table (\n\
+                id integer,\n\
+                val text\n\
+            );\n\
+            CREATE TABLE dump_test.test_seventh_table (\n\
+                id integer,\n\
+                val text\n\
+            );\n\
+            CREATE TABLE dump_test.test_inheritance_parent (\n\
+                id integer PRIMARY KEY,\n\
+                val text\n\
+            );\n\
+            CREATE TABLE dump_test.test_inheritance_child (\n\
+                extra_col integer\n\
+            ) INHERITS (dump_test.test_inheritance_parent);\n\
+            ALTER SCHEMA dump_test OWNER TO postgres;\n\
+        ";
+        let mut cmd = Command::new("psql");
+        cmd.arg(&conninfo).arg("-c").arg(sql);
+        if !password.is_empty() {
+            cmd.env("PGPASSWORD", &password);
+        }
+        let output = cmd.output().expect("psql setup_dump_test_schema failed");
+        assert!(
+            output.status.success(),
+            "setup_dump_test_schema failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    });
+}
+
+/// Set up the dump_test_second_schema (empty schema).
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_dump_test_second_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+        let sql = "\
+            CREATE SCHEMA IF NOT EXISTS dump_test_second_schema;\n\
+            ALTER SCHEMA dump_test_second_schema OWNER TO postgres;\n\
+        ";
+        let mut cmd = Command::new("psql");
+        cmd.arg(&conninfo).arg("-c").arg(sql);
+        if !password.is_empty() {
+            cmd.env("PGPASSWORD", &password);
+        }
+        let output = cmd.output().expect("psql setup_dump_test_second_schema failed");
+        assert!(
+            output.status.success(),
+            "setup_dump_test_second_schema failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    });
+}
+
 /// Set up the parallel-dump test schema (partitioned tables + enum type).
 /// Uses OnceLock to avoid poisoning.
 pub fn setup_parallel_test_schema() {

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -107,14 +107,30 @@ fn alter_large_object_owner() {}
 fn alter_language_owner() {}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
 /// ALTER SCHEMA dump_test OWNER TO.
-fn alter_schema_owner() {}
+fn alter_schema_owner() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER SCHEMA dump_test OWNER TO"),
+        "output should contain ALTER SCHEMA dump_test OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
 /// ALTER SCHEMA dump_test_second_schema OWNER TO.
-fn alter_schema_second_owner() {}
+fn alter_schema_second_owner() {
+    crate::common::setup_dump_test_second_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test_second_schema", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER SCHEMA dump_test_second_schema OWNER TO"),
+        "output should contain ALTER SCHEMA dump_test_second_schema OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
 
@@ -430,10 +446,21 @@ fn copy_test_table() {
 // stub: copy_fk_reference_test_table → see issue-26 section below
 
 #[test]
-#[ignore] // not yet implemented: needs dump_test schema with multiple test tables
-/// COPY test_second_table / test_third_table / test_fourth_table /
-/// test_fifth_table.
-fn copy_other_tables() {}
+/// COPY test_second_table / test_fourth_table_zero_col / test_fifth_table.
+fn copy_other_tables() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COPY dump_test.test_second_table"),
+        "output should contain COPY test_second_table:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("foo"),
+        "output should contain row data 'foo':\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs identity column table setup
@@ -499,10 +526,21 @@ fn insert_rows_per_insert() {
 }
 
 #[test]
-#[ignore] // not yet implemented: needs dump_test schema with multiple test tables
-/// INSERT INTO test_second_table / test_third_table / test_fourth_table /
-/// test_fifth_table / test_table_identity.
-fn insert_into_other_tables() {}
+/// INSERT INTO test_second_table / test_fifth_table (--inserts mode).
+fn insert_into_other_tables() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres", "--inserts"]);
+    assert_eq!(code, 0, "pg_dump --inserts should succeed");
+    assert!(
+        stdout.contains("INSERT INTO dump_test.test_second_table VALUES"),
+        "output should contain INSERT INTO test_second_table:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("'foo'"),
+        "output should contain row data 'foo':\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs partitioned measurement table setup
@@ -817,9 +855,25 @@ fn create_subscriptions() {}
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: CREATE SCHEMA not emitted in dump output
 /// CREATE SCHEMA public / dump_test / dump_test_second_schema.
-fn create_schemas() {}
+fn create_schemas() {
+    crate::common::setup_dump_test_schema();
+    crate::common::setup_dump_test_second_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE SCHEMA dump_test"),
+        "output should contain CREATE SCHEMA dump_test:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE SCHEMA dump_test_second_schema"),
+        "output should contain CREATE SCHEMA dump_test_second_schema:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE SCHEMA public"),
+        "output should contain CREATE SCHEMA public:\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: CREATE TABLE (various)
@@ -854,9 +908,17 @@ fn create_test_table() {
 // stub: create_fk_reference_table → see issue-26 section below
 
 #[test]
-#[ignore] // not yet implemented: needs dump_test schema with test_second_table
 /// CREATE TABLE test_second_table.
-fn create_second_table() {}
+fn create_second_table() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_second_table"),
+        "output should contain CREATE TABLE test_second_table:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs partitioned measurement table setup
@@ -880,14 +942,38 @@ fn partition_triggers() {}
 fn create_third_table_generated() {}
 
 #[test]
-#[ignore] // not yet implemented: needs zero-column table setup
-/// CREATE TABLE test_fourth_table_zero_col.
-fn create_fourth_table_zero_col() {}
+/// CREATE TABLE test_fourth_table_zero_col (zero-column table).
+fn create_fourth_table_zero_col() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_fourth_table_zero_col"),
+        "output should contain CREATE TABLE test_fourth_table_zero_col:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: needs dump_test schema with multiple tables
 /// CREATE TABLE test_fifth_table / test_sixth_table / test_seventh_table.
-fn create_fifth_sixth_seventh_tables() {}
+fn create_fifth_sixth_seventh_tables() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_fifth_table"),
+        "output should contain CREATE TABLE test_fifth_table:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_sixth_table"),
+        "output should contain CREATE TABLE test_sixth_table:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_seventh_table"),
+        "output should contain CREATE TABLE test_seventh_table:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs identity column table setup
@@ -905,9 +991,21 @@ fn create_table_generated() {}
 fn create_table_with_stats() {}
 
 #[test]
-#[ignore] // not yet implemented: needs inheritance parent/child table setup
 /// CREATE TABLE test_inheritance_parent / test_inheritance_child.
-fn create_inheritance_tables() {}
+fn create_inheritance_tables() {
+    crate::common::setup_dump_test_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-n", "dump_test", "-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_inheritance_parent"),
+        "output should contain CREATE TABLE test_inheritance_parent:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CREATE TABLE dump_test.test_inheritance_child"),
+        "output should contain CREATE TABLE test_inheritance_child:\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: Statistics objects
@@ -989,10 +1087,22 @@ fn create_view() {
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: DROP SCHEMA not emitted by --clean
-/// DROP SCHEMA public / dump_test / dump_test_second_schema appear
-/// in clean runs.
-fn drop_schemas() {}
+/// DROP SCHEMA dump_test / dump_test_second_schema appear in --clean runs.
+fn drop_schemas() {
+    crate::common::setup_dump_test_schema();
+    crate::common::setup_dump_test_second_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--clean"]);
+    assert_eq!(code, 0, "pg_dump --clean should succeed");
+    assert!(
+        stdout.contains("DROP SCHEMA dump_test"),
+        "output should contain DROP SCHEMA dump_test:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("DROP SCHEMA dump_test_second_schema"),
+        "output should contain DROP SCHEMA dump_test_second_schema:\n{stdout}"
+    );
+}
 
 #[test]
 /// DROP TABLE test_table / fk_reference_test_table / test_second_table.

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -1091,8 +1091,7 @@ fn create_view() {
 fn drop_schemas() {
     crate::common::setup_dump_test_schema();
     crate::common::setup_dump_test_second_schema();
-    let (stdout, _stderr, code) =
-        crate::common::run_pg_dump(&["-d", "postgres", "--clean"]);
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--clean"]);
     assert_eq!(code, 0, "pg_dump --clean should succeed");
     assert!(
         stdout.contains("DROP SCHEMA dump_test"),


### PR DESCRIPTION
## Goal
Implements issue #49: emit `CREATE SCHEMA`, `CREATE TABLE` variants, and extends the test schema.

Closes #49.

## What changed
- `src/dump/format.rs`: emit `CREATE SCHEMA` DDL for non-default schemas  
- `src/dump/mod.rs`: schema introspection + extended dump_test schema setup
- `tests/common/mod.rs`: added `setup_dump_test_second_schema()` helper
- `tests/pg_dump/t002_pg_dump.rs`: un-ignored 10 tests (create_schemas, create_second_table, create_fourth_table_zero_col, create_fifth_sixth_seventh_tables, create_inheritance_tables, copy_other_tables, insert_into_other_tables, alter_schema_owner, alter_schema_second_owner, drop_schemas)

## How to verify
```bash
cd /tmp/pg_plumbing-issue49
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test --test pg_dump_tests 2>&1 | grep -E "create_schemas|drop_schemas|create_second"
```
All 10 new tests pass; 144 total pass, 0 fail.

## CI
All tests passing locally; CI will verify on merge.