### PR TITLE
feat: emit large objects, policies, ALTER TABLE storage/statistics (closes #52)

### DIFF
--- a/src/bin/pg_dump.rs
+++ b/src/bin/pg_dump.rs
@@ -128,6 +128,18 @@ struct Cli {
     #[arg(short = 'x', long = "no-acl", alias = "no-privileges")]
     no_acl: bool,
 
+    /// Do not dump large objects
+    #[arg(long = "no-large-objects")]
+    no_large_objects: bool,
+
+    /// Dump large objects even when a schema filter is active
+    #[arg(short = 'b', long = "large-objects")]
+    large_objects: bool,
+
+    /// Do not dump row-level security policies
+    #[arg(long = "no-policies")]
+    no_policies: bool,
+
     // ---- Connection options ----
     /// Database server host or socket directory (overrides PGHOST)
     #[arg(short = 'h', long = "host")]
@@ -340,6 +352,9 @@ fn main() {
         clean: cli.clean,
         if_exists: cli.if_exists,
         create_db: cli.create,
+        no_large_objects: cli.no_large_objects,
+        large_objects: cli.large_objects,
+        no_policies: cli.no_policies,
     };
 
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");

--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -33,6 +33,10 @@ pub struct TableInfo {
     pub parent_table: Option<String>,
     /// Schema of the parent partitioned table — Some for partition children.
     pub parent_schema: Option<String>,
+    /// Whether row-level security is enabled on this table.
+    pub rls_enabled: bool,
+    /// Index name marked for CLUSTER ON, if any.
+    pub cluster_index: Option<String>,
 }
 
 /// Metadata for a single column.
@@ -46,6 +50,12 @@ pub struct ColumnInfo {
     pub not_null: bool,
     /// Default expression, if any.
     pub default_expr: Option<String>,
+    /// Custom statistics target: Some(n) if explicitly set (n≥0); None = use system default.
+    pub statistics: Option<i32>,
+    /// Storage override: Some('p'/'e'/'x'/'m') when different from the type default.
+    pub storage_override: Option<char>,
+    /// Column-level `n_distinct` option from `attoptions`, if set.
+    pub n_distinct: Option<f64>,
 }
 
 /// Metadata for a constraint.
@@ -168,7 +178,13 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                          JOIN pg_catalog.pg_class p ON p.oid = i.inhparent
                          JOIN pg_catalog.pg_namespace pn ON pn.oid = p.relnamespace
                          WHERE i.inhrelid = c.oid
-                         LIMIT 1) AS parent_schema
+                         LIMIT 1) AS parent_schema,
+                        c.relrowsecurity,
+                        (SELECT ci.relname
+                         FROM pg_catalog.pg_index idx
+                         JOIN pg_catalog.pg_class ci ON ci.oid = idx.indexrelid
+                         WHERE idx.indrelid = c.oid AND idx.indisclustered = true
+                         LIMIT 1) AS cluster_index
                  from pg_catalog.pg_class c
                  join pg_catalog.pg_namespace n on n.oid = c.relnamespace
                  join pg_catalog.pg_roles r on r.oid = c.relowner
@@ -207,7 +223,13 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
                              JOIN pg_catalog.pg_class p ON p.oid = i.inhparent
                              JOIN pg_catalog.pg_namespace pn ON pn.oid = p.relnamespace
                              WHERE i.inhrelid = c.oid
-                             LIMIT 1) AS parent_schema
+                             LIMIT 1) AS parent_schema,
+                            c.relrowsecurity,
+                            (SELECT ci.relname
+                             FROM pg_catalog.pg_index idx
+                             JOIN pg_catalog.pg_class ci ON ci.oid = idx.indexrelid
+                             WHERE idx.indrelid = c.oid AND idx.indisclustered = true
+                             LIMIT 1) AS cluster_index
                      from pg_catalog.pg_class c
                      join pg_catalog.pg_namespace n
                        on n.oid = c.relnamespace
@@ -236,6 +258,8 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
         let partition_bound: Option<String> = row.get("partition_bound");
         let parent_table: Option<String> = row.get("parent_table");
         let parent_schema: Option<String> = row.get("parent_schema");
+        let rls_enabled: bool = row.get("relrowsecurity");
+        let cluster_index: Option<String> = row.get("cluster_index");
 
         // Schema inclusion filter (supports glob patterns).
         if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
@@ -268,6 +292,8 @@ pub async fn get_tables(client: &Client, opts: &DumpOptions) -> Result<Vec<Table
             partition_bound: partition_bound.filter(|s| !s.is_empty()),
             parent_table,
             parent_schema,
+            rls_enabled,
+            cluster_index,
         });
     }
 
@@ -606,10 +632,15 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
             "select a.attname, \
                     pg_catalog.format_type(a.atttypid, a.atttypmod) as type_name, \
                     a.attnotnull, \
-                    pg_catalog.pg_get_expr(d.adbin, d.adrelid) as default_expr \
+                    pg_catalog.pg_get_expr(d.adbin, d.adrelid) as default_expr, \
+                    a.attstattarget::int4 as attstattarget, \
+                    a.attstorage::text as attstorage, \
+                    t.typstorage::text as typstorage, \
+                    COALESCE(array_to_string(a.attoptions, ','), '') as attoptions \
              from pg_catalog.pg_attribute a \
              left join pg_catalog.pg_attrdef d \
                on d.adrelid = a.attrelid and d.adnum = a.attnum \
+             join pg_catalog.pg_type t on t.oid = a.atttypid \
              where a.attrelid = $1::bigint::oid \
                and a.attnum > 0 \
                and not a.attisdropped \
@@ -621,14 +652,42 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
 
     let mut columns = Vec::new();
     for row in &rows {
+        let attstattarget: Option<i32> = row.get("attstattarget");
+        let attstorage: &str = row.get("attstorage");
+        let typstorage: &str = row.get("typstorage");
+        let attoptions: &str = row.get("attoptions");
+
+        // Determine storage override: only emit if different from type default.
+        let storage_override = if attstorage != typstorage {
+            attstorage.chars().next()
+        } else {
+            None
+        };
+
+        // Parse n_distinct from attoptions (e.g. "n_distinct=5,n_distinct_inherited=5").
+        let n_distinct = parse_n_distinct(attoptions);
+
         columns.push(ColumnInfo {
             name: row.get("attname"),
             type_name: row.get("type_name"),
             not_null: row.get("attnotnull"),
             default_expr: row.get("default_expr"),
+            statistics: attstattarget, // Some(n) if explicitly set, None = system default
+            storage_override,
+            n_distinct,
         });
     }
     Ok(columns)
+}
+
+/// Parse the `n_distinct` value from a comma-separated `attoptions` string.
+fn parse_n_distinct(attoptions: &str) -> Option<f64> {
+    for part in attoptions.split(',') {
+        if let Some(val_str) = part.strip_prefix("n_distinct=") {
+            return val_str.parse::<f64>().ok();
+        }
+    }
+    None
 }
 
 /// Query all constraints for a table by OID.
@@ -1634,6 +1693,146 @@ pub async fn get_publications(client: &Client) -> Result<Vec<PublicationInfo>> {
     }
 
     Ok(publications)
+}
+
+/// Metadata for a large object.
+#[derive(Debug, Clone)]
+pub struct LargeObjectInfo {
+    /// The large object OID.
+    pub oid: u32,
+    /// Owner role name.
+    pub owner: String,
+    /// Comment text, if any.
+    pub comment: Option<String>,
+    /// Raw ACL string (comma-separated aclitem entries), or empty.
+    pub acl: String,
+    /// Hex-encoded binary content of the large object.
+    pub hex_data: String,
+}
+
+/// Query large objects from the catalog, including their data.
+pub async fn get_large_objects(client: &Client) -> Result<Vec<LargeObjectInfo>> {
+    let rows = client
+        .query(
+            "SELECT lm.oid::bigint AS lo_oid,
+                    r.rolname AS owner,
+                    d.description AS comment,
+                    COALESCE(array_to_string(lm.lomacl, ','), '') AS acl_str,
+                    COALESCE(encode(lo_get(lm.oid), 'hex'), '') AS hex_data
+             FROM pg_catalog.pg_largeobject_metadata lm
+             JOIN pg_catalog.pg_roles r ON r.oid = lm.lomowner
+             LEFT JOIN pg_catalog.pg_description d
+               ON d.objoid = lm.oid
+              AND d.classoid = 'pg_catalog.pg_largeobject'::regclass
+             ORDER BY lm.oid",
+            &[],
+        )
+        .await
+        .context("query large objects")?;
+
+    let mut los = Vec::new();
+    for row in &rows {
+        let oid: i64 = row.get("lo_oid");
+        los.push(LargeObjectInfo {
+            oid: oid as u32,
+            owner: row.get::<_, &str>("owner").to_string(),
+            comment: row.get("comment"),
+            acl: row.get::<_, &str>("acl_str").to_string(),
+            hex_data: row.get::<_, &str>("hex_data").to_string(),
+        });
+    }
+    Ok(los)
+}
+
+/// Metadata for a row-level security policy.
+#[derive(Debug, Clone)]
+pub struct PolicyInfo {
+    /// Schema of the table the policy is on.
+    pub table_schema: String,
+    /// Table name the policy is on.
+    pub table_name: String,
+    /// Policy name.
+    pub name: String,
+    /// Command: ALL, SELECT, INSERT, UPDATE, DELETE.
+    pub command: String,
+    /// true = PERMISSIVE (default), false = RESTRICTIVE.
+    pub permissive: bool,
+    /// USING expression, if any.
+    pub using_expr: Option<String>,
+    /// WITH CHECK expression, if any.
+    pub check_expr: Option<String>,
+    /// Roles this policy applies to (empty means all roles / no TO clause).
+    pub roles: Vec<String>,
+    /// Comment on this policy, if any.
+    pub comment: Option<String>,
+}
+
+/// Query row-level security policies from the catalog.
+pub async fn get_policies(client: &Client, opts: &DumpOptions) -> Result<Vec<PolicyInfo>> {
+    let rows = client
+        .query(
+            "SELECT n.nspname AS table_schema,
+                    c.relname AS table_name,
+                    p.polname AS policy_name,
+                    CASE p.polcmd::text
+                        WHEN 'r' THEN 'SELECT'
+                        WHEN 'a' THEN 'INSERT'
+                        WHEN 'w' THEN 'UPDATE'
+                        WHEN 'd' THEN 'DELETE'
+                        ELSE 'ALL'
+                    END AS command,
+                    p.polpermissive AS permissive,
+                    pg_catalog.pg_get_expr(p.polqual, p.polrelid) AS using_expr,
+                    pg_catalog.pg_get_expr(p.polwithcheck, p.polrelid) AS check_expr,
+                    ARRAY(
+                        SELECT r.rolname
+                        FROM pg_catalog.pg_roles r
+                        WHERE r.oid = ANY(p.polroles) AND r.oid != 0
+                        ORDER BY r.rolname
+                    ) AS roles,
+                    d.description AS comment
+             FROM pg_catalog.pg_policy p
+             JOIN pg_catalog.pg_class c ON c.oid = p.polrelid
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+             LEFT JOIN pg_catalog.pg_description d
+               ON d.objoid = p.oid
+              AND d.classoid = 'pg_catalog.pg_policy'::regclass
+             WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+             ORDER BY n.nspname, c.relname, p.polname",
+            &[],
+        )
+        .await
+        .context("query policies")?;
+
+    let mut policies = Vec::new();
+    for row in &rows {
+        let table_schema: &str = row.get("table_schema");
+
+        // Apply schema filters.
+        if !opts.schemas.is_empty()
+            && !super::filter::schema_matches_any(&opts.schemas, table_schema)
+        {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, table_schema) {
+            continue;
+        }
+
+        let roles: Vec<String> = row.get("roles");
+
+        policies.push(PolicyInfo {
+            table_schema: table_schema.to_string(),
+            table_name: row.get::<_, &str>("table_name").to_string(),
+            name: row.get::<_, &str>("policy_name").to_string(),
+            command: row.get::<_, &str>("command").to_string(),
+            permissive: row.get("permissive"),
+            using_expr: row.get("using_expr"),
+            check_expr: row.get("check_expr"),
+            roles,
+            comment: row.get("comment"),
+        });
+    }
+    Ok(policies)
 }
 
 /// Quote an SQL identifier if it needs quoting.

--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -667,12 +667,20 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
         // Parse n_distinct from attoptions (e.g. "n_distinct=5,n_distinct_inherited=5").
         let n_distinct = parse_n_distinct(attoptions);
 
+        // attstattarget = -1 means "use the system default" — treat as None so we
+        // don't emit a spurious `SET STATISTICS -1` statement.  Only Some(n) with
+        // n >= 0 represents a value explicitly set by the user.
+        let statistics = match attstattarget {
+            Some(n) if n >= 0 => Some(n),
+            _ => None,
+        };
+
         columns.push(ColumnInfo {
             name: row.get("attname"),
             type_name: row.get("type_name"),
             not_null: row.get("attnotnull"),
             default_expr: row.get("default_expr"),
-            statistics: attstattarget, // Some(n) if explicitly set, None = system default
+            statistics, // Some(n≥0) if explicitly set by user, None = system default
             storage_override,
             n_distinct,
         });

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -7,10 +7,10 @@ use anyhow::{Context, Result};
 use tokio_postgres::Client;
 
 use super::catalog::{
-    format_fdw_options, quote_ident, ConstraintInfo, EventTriggerInfo, ExtendedStatInfo, FdwInfo,
-    ForeignServerInfo, ForeignTableInfo, FunctionInfo, MatviewInfo, PrivilegeInfo, PublicationInfo,
-    SchemaInfo, SequenceInfo, TableInfo, TransformInfo, TriggerInfo, TypeCommentInfo,
-    UserMappingInfo, ViewInfo,
+    format_fdw_options, parse_acl_entry, quote_ident, ColumnInfo, ConstraintInfo, EventTriggerInfo,
+    ExtendedStatInfo, FdwInfo, ForeignServerInfo, ForeignTableInfo, FunctionInfo, LargeObjectInfo,
+    MatviewInfo, PolicyInfo, PrivilegeInfo, PublicationInfo, SchemaInfo, SequenceInfo, TableInfo,
+    TransformInfo, TriggerInfo, TypeCommentInfo, UserMappingInfo, ViewInfo,
 };
 use super::DumpOptions;
 
@@ -863,6 +863,179 @@ pub fn write_alter_publication_tables(out: &mut String, pub_info: &PublicationIn
             quote_ident(schema)
         ));
     }
+}
+
+/// Write a large object creation statement.
+///
+/// Uses `pg_catalog.lo_from_bytea(oid, data)`.  When `include_data` is false
+/// (schema-only mode) the data argument is an empty string so only the OID
+/// (object metadata) is restored.
+pub fn write_create_large_object(out: &mut String, lo: &LargeObjectInfo, include_data: bool) {
+    out.push_str(&format!("--\n-- LARGE OBJECT {}\n--\n\n", lo.oid));
+    if include_data && !lo.hex_data.is_empty() {
+        out.push_str(&format!(
+            "SELECT pg_catalog.lo_from_bytea({}, '\\x{}');\n",
+            lo.oid, lo.hex_data
+        ));
+    } else {
+        out.push_str(&format!(
+            "SELECT pg_catalog.lo_from_bytea({}, '');\n",
+            lo.oid
+        ));
+    }
+}
+
+/// Write `ALTER LARGE OBJECT … OWNER TO …;` statement.
+pub fn write_alter_large_object_owner(out: &mut String, lo: &LargeObjectInfo) {
+    out.push_str(&format!(
+        "ALTER LARGE OBJECT {} OWNER TO {};\n",
+        lo.oid,
+        quote_ident(&lo.owner)
+    ));
+}
+
+/// Write `COMMENT ON LARGE OBJECT … IS '…';` if a comment is set.
+pub fn write_comment_on_large_object(out: &mut String, lo: &LargeObjectInfo) {
+    if let Some(ref comment) = lo.comment {
+        let escaped = comment.replace('\'', "''");
+        out.push_str(&format!(
+            "COMMENT ON LARGE OBJECT {} IS '{}';\n",
+            lo.oid, escaped
+        ));
+    }
+}
+
+/// Write `GRANT … ON LARGE OBJECT …` privilege statements.
+pub fn write_grant_large_object(out: &mut String, lo: &LargeObjectInfo) {
+    if lo.acl.is_empty() {
+        return;
+    }
+    for entry in lo.acl.split(',') {
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((grantee, privileges)) = parse_acl_entry(entry) {
+            // Large objects only have SELECT (r) and UPDATE (w).
+            // When both are granted, emit ALL for brevity.
+            let has_select = privileges.iter().any(|p| p == "SELECT");
+            let has_update = privileges.iter().any(|p| p == "UPDATE");
+            let priv_str = if has_select && has_update {
+                "ALL".to_string()
+            } else {
+                privileges.join(", ")
+            };
+            out.push_str(&format!(
+                "GRANT {} ON LARGE OBJECT {} TO {};\n",
+                priv_str, lo.oid, grantee
+            ));
+        }
+    }
+}
+
+/// Write a `CREATE POLICY` statement.
+pub fn write_create_policy(out: &mut String, policy: &PolicyInfo) {
+    let qname = format!(
+        "{}.{}",
+        quote_ident(&policy.table_schema),
+        quote_ident(&policy.table_name)
+    );
+
+    let mut stmt = format!("CREATE POLICY {} ON {}", quote_ident(&policy.name), qname);
+
+    if !policy.permissive {
+        stmt.push_str(" AS RESTRICTIVE");
+    }
+
+    if policy.command != "ALL" {
+        stmt.push_str(&format!(" FOR {}", policy.command));
+    }
+
+    if !policy.roles.is_empty() {
+        let role_list: Vec<String> = policy.roles.iter().map(|r| quote_ident(r)).collect();
+        stmt.push_str(&format!(" TO {}", role_list.join(", ")));
+    }
+
+    if let Some(ref using) = policy.using_expr {
+        stmt.push_str(&format!(" USING ({})", using));
+    }
+
+    if let Some(ref check) = policy.check_expr {
+        stmt.push_str(&format!(" WITH CHECK ({})", check));
+    }
+
+    stmt.push_str(";\n");
+    out.push_str(&stmt);
+}
+
+/// Write `ALTER TABLE … ENABLE ROW LEVEL SECURITY;` for RLS-enabled tables.
+pub fn write_alter_table_enable_rls(out: &mut String, table: &TableInfo) {
+    let qname = table.qualified_name();
+    out.push_str(&format!(
+        "ALTER TABLE {} ENABLE ROW LEVEL SECURITY;\n",
+        qname
+    ));
+}
+
+/// Write `ALTER TABLE ONLY … ALTER COLUMN … SET STATISTICS N;`
+pub fn write_alter_column_statistics(out: &mut String, table: &TableInfo, col: &ColumnInfo) {
+    if let Some(stats) = col.statistics {
+        let qname = table.qualified_name();
+        out.push_str(&format!(
+            "ALTER TABLE ONLY {} ALTER COLUMN {} SET STATISTICS {};\n",
+            qname,
+            quote_ident(&col.name),
+            stats
+        ));
+    }
+}
+
+/// Write `ALTER TABLE ONLY … ALTER COLUMN … SET STORAGE X;`
+pub fn write_alter_column_storage(out: &mut String, table: &TableInfo, col: &ColumnInfo) {
+    if let Some(storage_char) = col.storage_override {
+        let storage_name = match storage_char {
+            'p' => "PLAIN",
+            'e' => "EXTERNAL",
+            'x' => "EXTENDED",
+            'm' => "MAIN",
+            _ => return,
+        };
+        let qname = table.qualified_name();
+        out.push_str(&format!(
+            "ALTER TABLE ONLY {} ALTER COLUMN {} SET STORAGE {};\n",
+            qname,
+            quote_ident(&col.name),
+            storage_name
+        ));
+    }
+}
+
+/// Write `ALTER TABLE ONLY … ALTER COLUMN … SET (n_distinct = V);`
+pub fn write_alter_column_n_distinct(out: &mut String, table: &TableInfo, col: &ColumnInfo) {
+    if let Some(nd) = col.n_distinct {
+        let qname = table.qualified_name();
+        // Format as integer when there's no fractional part.
+        let nd_str = if nd.fract() == 0.0 {
+            format!("{}", nd as i64)
+        } else {
+            format!("{}", nd)
+        };
+        out.push_str(&format!(
+            "ALTER TABLE ONLY {} ALTER COLUMN {} SET (n_distinct = {});\n",
+            qname,
+            quote_ident(&col.name),
+            nd_str
+        ));
+    }
+}
+
+/// Write `ALTER TABLE … CLUSTER ON index_name;`
+pub fn write_alter_table_cluster(out: &mut String, table: &TableInfo, index_name: &str) {
+    let qname = table.qualified_name();
+    out.push_str(&format!(
+        "ALTER TABLE {} CLUSTER ON {};\n",
+        qname,
+        quote_ident(index_name)
+    ));
 }
 
 #[cfg(test)]

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -977,8 +977,15 @@ pub fn write_alter_table_enable_rls(out: &mut String, table: &TableInfo) {
 }
 
 /// Write `ALTER TABLE ONLY … ALTER COLUMN … SET STATISTICS N;`
+///
+/// Only emits when the statistics target is explicitly set by the user (value ≥ 0).
+/// A value of -1 means "use the system default" and must NOT be emitted.
 pub fn write_alter_column_statistics(out: &mut String, table: &TableInfo, col: &ColumnInfo) {
     if let Some(stats) = col.statistics {
+        if stats < 0 {
+            // -1 is PostgreSQL's sentinel for "use default" — skip it.
+            return;
+        }
         let qname = table.qualified_name();
         out.push_str(&format!(
             "ALTER TABLE ONLY {} ALTER COLUMN {} SET STATISTICS {};\n",

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -51,6 +51,12 @@ pub struct DumpOptions {
     pub if_exists: bool,
     /// Include CREATE DATABASE + \connect at the start.
     pub create_db: bool,
+    /// Do not dump large objects.
+    pub no_large_objects: bool,
+    /// Include large objects even when a schema filter (--schema=X) is active.
+    pub large_objects: bool,
+    /// Do not dump row-level security policies.
+    pub no_policies: bool,
 }
 
 /// Dump a database in plain SQL format.
@@ -244,6 +250,30 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
             }
             format::write_create_table(&mut out, table);
             format::write_alter_table_owner(&mut out, table);
+
+            // Emit column-level storage, statistics, and n_distinct overrides.
+            for col in &table.columns {
+                if col.storage_override.is_some() {
+                    format::write_alter_column_storage(&mut out, table, col);
+                }
+                if col.statistics.is_some() {
+                    format::write_alter_column_statistics(&mut out, table, col);
+                }
+                if col.n_distinct.is_some() {
+                    format::write_alter_column_n_distinct(&mut out, table, col);
+                }
+            }
+
+            // Emit CLUSTER ON if a cluster index is marked.
+            if let Some(ref idx) = table.cluster_index {
+                format::write_alter_table_cluster(&mut out, table, idx);
+            }
+
+            // Emit ENABLE ROW LEVEL SECURITY.
+            if table.rls_enabled {
+                format::write_alter_table_enable_rls(&mut out, table);
+            }
+
             out.push('\n');
         }
 
@@ -396,6 +426,57 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
                 format::write_privileges(&mut out, &privileges);
                 out.push('\n');
             }
+        }
+    }
+
+    // Emit large objects.
+    // Included when: no --no-large-objects AND (no schema filter OR --large-objects).
+    if !opts.data_only && !opts.no_large_objects && (opts.schemas.is_empty() || opts.large_objects)
+    {
+        let large_objects = catalog::get_large_objects(&client)
+            .await
+            .context("failed to query large objects")?;
+        if !large_objects.is_empty() {
+            let include_data = !opts.schema_only;
+            for lo in &large_objects {
+                format::write_create_large_object(&mut out, lo, include_data);
+                format::write_alter_large_object_owner(&mut out, lo);
+            }
+            if !opts.no_privileges {
+                for lo in &large_objects {
+                    format::write_grant_large_object(&mut out, lo);
+                }
+            }
+            for lo in &large_objects {
+                format::write_comment_on_large_object(&mut out, lo);
+            }
+            out.push('\n');
+        }
+    }
+
+    // Emit row-level security policies.
+    if !opts.data_only && !table_filter_active && !opts.no_policies {
+        let policies = catalog::get_policies(&client, opts)
+            .await
+            .context("failed to query policies")?;
+        if !policies.is_empty() {
+            for policy in &policies {
+                format::write_create_policy(&mut out, policy);
+            }
+            // Emit COMMENT ON POLICY.
+            for policy in &policies {
+                if let Some(ref comment) = policy.comment {
+                    let escaped = comment.replace('\'', "''");
+                    out.push_str(&format!(
+                        "COMMENT ON POLICY {} ON {}.{} IS '{}';\n",
+                        catalog::quote_ident(&policy.name),
+                        catalog::quote_ident(&policy.table_schema),
+                        catalog::quote_ident(&policy.table_name),
+                        escaped
+                    ));
+                }
+            }
+            out.push('\n');
         }
     }
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -270,7 +270,7 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
             }
 
             // Emit ENABLE ROW LEVEL SECURITY.
-            if table.rls_enabled {
+            if table.rls_enabled && !opts.no_policies {
                 format::write_alter_table_enable_rls(&mut out, table);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,18 @@ pub struct PgDumpArgs {
     #[arg(short = 'C', long = "create")]
     create_db: bool,
 
+    /// Do not dump large objects.
+    #[arg(long = "no-large-objects")]
+    no_large_objects: bool,
+
+    /// Dump large objects even when a schema filter is active.
+    #[arg(short = 'b', long = "large-objects")]
+    large_objects: bool,
+
+    /// Do not dump row-level security policies.
+    #[arg(long = "no-policies")]
+    no_policies: bool,
+
     /// Positional database name (alternative to -d).
     #[arg()]
     database: Option<String>,
@@ -188,6 +200,9 @@ async fn run_pg_dump(args: PgDumpArgs) -> Result<()> {
         clean: args.clean,
         if_exists: args.if_exists,
         create_db: args.create_db,
+        no_large_objects: args.no_large_objects,
+        large_objects: args.large_objects,
+        no_policies: args.no_policies,
     };
 
     match args.format {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -486,6 +486,88 @@ pub fn setup_issue50_schema() {
     });
 }
 
+/// Set up the issue-52 test schema: large objects, RLS policies, and
+/// column-level storage/statistics/n_distinct/cluster overrides.
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_issue52_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        // We need test_table from issue-50 (col1 int PK, col2 text).
+        setup_issue50_schema();
+
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+
+        // Step 1: Add columns and set statistics/storage/n_distinct/cluster.
+        let sql1 = "
+ALTER TABLE test_table ADD COLUMN IF NOT EXISTS col3 text;
+ALTER TABLE test_table ADD COLUMN IF NOT EXISTS col4 real;
+ALTER TABLE ONLY test_table ALTER COLUMN col1 SET STATISTICS 90;
+ALTER TABLE ONLY test_table ALTER COLUMN col2 SET STORAGE EXTERNAL;
+ALTER TABLE ONLY test_table ALTER COLUMN col3 SET STORAGE MAIN;
+ALTER TABLE ONLY test_table ALTER COLUMN col4 SET (n_distinct = 5);
+ALTER TABLE test_table CLUSTER ON test_table_pkey;
+        ";
+
+        // Step 2: Create RLS policies and enable RLS.
+        // Drop any existing policies first to make the setup idempotent.
+        let sql2 = "
+DROP POLICY IF EXISTS p1 ON test_table;
+DROP POLICY IF EXISTS p2 ON test_table;
+DROP POLICY IF EXISTS p3 ON test_table;
+DROP POLICY IF EXISTS p4 ON test_table;
+DROP POLICY IF EXISTS p5 ON test_table;
+DROP POLICY IF EXISTS p6 ON test_table;
+CREATE POLICY p1 ON test_table FOR SELECT USING (true);
+CREATE POLICY p2 ON test_table FOR INSERT WITH CHECK (true);
+CREATE POLICY p3 ON test_table FOR UPDATE USING (true) WITH CHECK (false);
+CREATE POLICY p4 ON test_table FOR DELETE USING (true);
+CREATE POLICY p5 ON test_table AS RESTRICTIVE USING (false);
+CREATE POLICY p6 ON test_table;
+ALTER TABLE test_table ENABLE ROW LEVEL SECURITY;
+COMMENT ON POLICY p1 ON test_table IS 'test policy comment';
+        ";
+
+        // Step 3: Create a large object with data, then set owner, grant, comment.
+        // We use a DO block to capture the OID and apply the subsequent statements.
+        let sql3 = "
+DO $$
+DECLARE
+  v_oid oid;
+BEGIN
+  FOR v_oid IN
+    SELECT oid FROM pg_catalog.pg_largeobject_metadata
+    WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = current_user)
+  LOOP
+    PERFORM lo_unlink(v_oid);
+  END LOOP;
+  v_oid := lo_from_bytea(0, 'hello world'::bytea);
+  EXECUTE format(
+    'COMMENT ON LARGE OBJECT %s IS ''test large object comment''',
+    v_oid
+  );
+  EXECUTE format('GRANT ALL ON LARGE OBJECT %s TO PUBLIC', v_oid);
+END $$;
+        ";
+
+        for (step, sql) in [sql1, sql2, sql3].iter().enumerate() {
+            let mut cmd = Command::new("psql");
+            cmd.arg(&conninfo).arg("-c").arg(sql);
+            if !password.is_empty() {
+                cmd.env("PGPASSWORD", &password);
+            }
+            let output = cmd.output().expect("psql setup_issue52 failed");
+            assert!(
+                output.status.success(),
+                "setup_issue52_schema step {} failed: {}",
+                step + 1,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    });
+}
+
 /// Set up the issue-51 test schema: FDW, foreign server, foreign table,
 /// user mapping, publications, and publication comments.
 /// Uses OnceLock to avoid poisoning.

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -118,9 +118,16 @@ fn alter_publication_owner() {
 }
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted + needs large object
 /// ALTER LARGE OBJECT ... OWNER TO.
-fn alter_large_object_owner() {}
+fn alter_large_object_owner() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER LARGE OBJECT") && stdout.contains("OWNER TO"),
+        "output should contain ALTER LARGE OBJECT ... OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: OWNER TO not emitted + needs procedural language
@@ -228,29 +235,84 @@ fn alter_table_add_primary_key() {
 // stub: alter_table_partitioned_fk    → see issue-26 section below
 
 #[test]
-#[ignore] // not yet implemented: ALTER COLUMN SET STATISTICS not emitted
 /// ALTER TABLE ONLY test_table ALTER COLUMN col1 SET STATISTICS 90.
-fn alter_column_set_statistics() {}
+fn alter_column_set_statistics() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("SET STATISTICS"),
+        "output should contain SET STATISTICS:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("col1"),
+        "SET STATISTICS should reference col1:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: ALTER COLUMN SET STORAGE not emitted
-/// ALTER TABLE ONLY test_table ALTER COLUMN col2 SET STORAGE.
-fn alter_column_set_storage_col2() {}
+/// ALTER TABLE ONLY test_table ALTER COLUMN col2 SET STORAGE EXTERNAL.
+fn alter_column_set_storage_col2() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("SET STORAGE") && stdout.contains("EXTERNAL"),
+        "output should contain SET STORAGE EXTERNAL:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("col2"),
+        "SET STORAGE should reference col2:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: ALTER COLUMN SET STORAGE not emitted
-/// ALTER TABLE ONLY test_table ALTER COLUMN col3 SET STORAGE.
-fn alter_column_set_storage_col3() {}
+/// ALTER TABLE ONLY test_table ALTER COLUMN col3 SET STORAGE MAIN.
+fn alter_column_set_storage_col3() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("SET STORAGE") && stdout.contains("MAIN"),
+        "output should contain SET STORAGE MAIN:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("col3"),
+        "SET STORAGE should reference col3:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: ALTER COLUMN SET n_distinct not emitted
-/// ALTER TABLE ONLY test_table ALTER COLUMN col4 SET n_distinct.
-fn alter_column_set_n_distinct() {}
+/// ALTER TABLE ONLY test_table ALTER COLUMN col4 SET (n_distinct = 5).
+fn alter_column_set_n_distinct() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("SET (n_distinct"),
+        "output should contain SET (n_distinct:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("col4"),
+        "SET (n_distinct should reference col4:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: CLUSTER ON not emitted
 /// ALTER TABLE test_table CLUSTER ON test_table_pkey.
-fn alter_table_cluster() {}
+fn alter_table_cluster() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CLUSTER ON"),
+        "output should contain CLUSTER ON:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("test_table"),
+        "CLUSTER ON should reference test_table:\n{stdout}"
+    );
+}
 
 #[test]
 /// ALTER TABLE test_table DISABLE TRIGGER ALL.
@@ -292,9 +354,20 @@ fn alter_foreign_table_column_options() {
 fn alter_table_owner() {}
 
 #[test]
-#[ignore] // not yet implemented: ENABLE ROW LEVEL SECURITY not emitted
 /// ALTER TABLE test_table ENABLE ROW LEVEL SECURITY.
-fn alter_table_enable_rls() {}
+fn alter_table_enable_rls() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ENABLE ROW LEVEL SECURITY"),
+        "output should contain ENABLE ROW LEVEL SECURITY:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("test_table"),
+        "ENABLE ROW LEVEL SECURITY should reference test_table:\n{stdout}"
+    );
+}
 
 #[test]
 
@@ -348,19 +421,51 @@ fn alter_ts_dict_owner() {}
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: large object support
-/// LO create (using lo_from_bytea) appears in appropriate runs.
-fn lo_create() {}
+/// LO create (using lo_from_bytea) appears in full dumps.
+fn lo_create() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("lo_from_bytea"),
+        "output should contain lo_from_bytea:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: large object support
-/// LO load (using lo_from_bytea).
-fn lo_load() {}
+/// LO load — full dump includes non-empty hex data for the large object.
+fn lo_load() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("lo_from_bytea"),
+        "output should contain lo_from_bytea:\n{stdout}"
+    );
+    // "hello world" in hex is 68656c6c6f20776f726c64 — non-empty data must be present.
+    assert!(
+        stdout.contains("\\x68") || stdout.contains("'\\x6"),
+        "lo_from_bytea should contain non-empty hex data:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: large object support
-/// LO create (with no data) for schema-only dumps.
-fn lo_create_no_data() {}
+/// LO create with no data — schema-only dump emits the LO OID but no content.
+fn lo_create_no_data() {
+    crate::common::setup_issue52_schema();
+    // --schema-only: LOs are still emitted (no schema filter) but with empty data.
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--schema-only"]);
+    assert_eq!(code, 0, "pg_dump --schema-only should succeed");
+    assert!(
+        stdout.contains("lo_from_bytea"),
+        "schema-only output should contain lo_from_bytea:\n{stdout}"
+    );
+    // Data should be empty ('') in schema-only mode.
+    assert!(
+        stdout.contains("lo_from_bytea") && stdout.contains(", '')"),
+        "schema-only lo_from_bytea should have empty data:\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: COMMENT ON
@@ -437,14 +542,32 @@ fn comment_on_conversion() {}
 fn comment_on_collation() {}
 
 #[test]
-#[ignore] // not yet implemented: COMMENT ON not emitted + needs large object
 /// COMMENT ON LARGE OBJECT.
-fn comment_on_large_object() {}
+fn comment_on_large_object() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COMMENT ON LARGE OBJECT"),
+        "output should contain COMMENT ON LARGE OBJECT:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: COMMENT ON not emitted + needs policy
 /// COMMENT ON POLICY p1.
-fn comment_on_policy() {}
+fn comment_on_policy() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("COMMENT ON POLICY"),
+        "output should contain COMMENT ON POLICY:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("p1"),
+        "COMMENT ON POLICY should reference p1:\n{stdout}"
+    );
+}
 
 #[test]
 /// COMMENT ON PUBLICATION pub1.
@@ -634,7 +757,6 @@ fn create_role() {}
 fn create_role_quoted() {}
 
 #[test]
-#[ignore] // not yet implemented: newline handling in table name comments
 /// Newline in table name handled in comments.
 fn newline_in_table_name_comment() {}
 
@@ -1083,9 +1205,28 @@ fn refresh_materialized_views() {
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore] // not yet implemented: CREATE POLICY not emitted + needs RLS setup
 /// CREATE POLICY p1..p6 ON test_table (various FOR clauses and RESTRICTIVE).
-fn create_policies() {}
+fn create_policies() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE POLICY"),
+        "output should contain CREATE POLICY:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("p1") && stdout.contains("p2"),
+        "output should contain policies p1 and p2:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("FOR SELECT") || stdout.contains("FOR INSERT"),
+        "output should contain FOR SELECT or FOR INSERT clause:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("AS RESTRICTIVE"),
+        "output should contain AS RESTRICTIVE (p5):\n{stdout}"
+    );
+}
 
 // ---------------------------------------------------------------
 // Module: Property Graph
@@ -1551,9 +1692,16 @@ fn grant_select_tables() {
 }
 
 #[test]
-#[ignore] // not yet implemented: GRANT not emitted + needs large object
 /// GRANT ALL ON LARGE OBJECT.
-fn grant_all_large_object() {}
+fn grant_all_large_object() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("GRANT") && stdout.contains("LARGE OBJECT"),
+        "output should contain GRANT ... LARGE OBJECT:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: GRANT not emitted in dump output
@@ -2102,14 +2250,29 @@ fn run_pg_dumpall_exclude() {}
 fn run_no_toast_compression() {}
 
 #[test]
-#[ignore] // not yet implemented: --no-large-objects flag not supported
 /// no_large_objects: pg_dump --no-large-objects.
-fn run_no_large_objects() {}
+fn run_no_large_objects() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--no-large-objects"]);
+    assert_eq!(code, 0, "pg_dump --no-large-objects should succeed");
+    assert!(
+        !stdout.contains("lo_from_bytea"),
+        "output should NOT contain lo_from_bytea with --no-large-objects:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: --no-policies flag not supported
 /// no_policies / no_policies_restore: pg_dump/pg_restore --no-policies.
-fn run_no_policies() {}
+fn run_no_policies() {
+    crate::common::setup_issue52_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres", "--no-policies"]);
+    assert_eq!(code, 0, "pg_dump --no-policies should succeed");
+    assert!(
+        !stdout.contains("CREATE POLICY"),
+        "output should NOT contain CREATE POLICY with --no-policies:\n{stdout}"
+    );
+}
 
 #[test]
 /// no_privs: pg_dump --no-privileges.
@@ -2239,9 +2402,30 @@ fn run_schema_only() {
 fn run_sections() {}
 
 #[test]
-#[ignore] // not yet implemented: --large-objects flag not supported
-/// test_schema_plus_large_objects: pg_dump --schema=dump_test --large-objects.
-fn run_schema_plus_large_objects() {}
+/// test_schema_plus_large_objects: pg_dump --schema=public --large-objects.
+/// With a schema filter alone, LOs are excluded; --large-objects forces them in.
+fn run_schema_plus_large_objects() {
+    crate::common::setup_issue52_schema();
+    // Confirm that without --large-objects the LO is excluded.
+    let (stdout_no_lo, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--schema=public"]);
+    assert_eq!(code, 0, "pg_dump --schema=public should succeed");
+    assert!(
+        !stdout_no_lo.contains("lo_from_bytea"),
+        "schema-filtered dump should NOT contain lo_from_bytea without --large-objects:\n{stdout_no_lo}"
+    );
+    // With --large-objects, LOs should be present despite the schema filter.
+    let (stdout, _stderr, code) =
+        crate::common::run_pg_dump(&["-d", "postgres", "--schema=public", "--large-objects"]);
+    assert_eq!(
+        code, 0,
+        "pg_dump --schema=public --large-objects should succeed"
+    );
+    assert!(
+        stdout.contains("lo_from_bytea"),
+        "output should contain lo_from_bytea with --large-objects even with schema filter:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: --no-statistics flag not supported by pg-dump subcommand

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -757,6 +757,7 @@ fn create_role() {}
 fn create_role_quoted() {}
 
 #[test]
+#[ignore]
 /// Newline in table name handled in comments.
 fn newline_in_table_name_comment() {}
 
@@ -2271,6 +2272,10 @@ fn run_no_policies() {
     assert!(
         !stdout.contains("CREATE POLICY"),
         "output should NOT contain CREATE POLICY with --no-policies:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("ENABLE ROW LEVEL SECURITY"),
+        "output should NOT contain ENABLE ROW LEVEL SECURITY with --no-policies:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## Goal
Enable t002 tests for large objects, row-level security policies, and ALTER TABLE storage/statistics flags. Closes #52.

## What changed
- `src/main.rs`: add `--no-large-objects`, `--large-objects`, `--no-policies` flags to the `pg-dump` subcommand and wire them into `DumpOptions`
- `src/bin/pg_dump.rs`: same flags already present (from previous agent work)
- `src/dump/catalog.rs`: queries for large objects, policies (from previous agent)
- `src/dump/format.rs`: emit functions for large objects, policies, ALTER TABLE storage (from previous agent)
- `src/dump/mod.rs`: wiring of emit functions + DumpOptions fields (from previous agent)
- `tests/common/mod.rs`: `setup_issue52_schema()` with LOs, RLS, storage settings (from previous agent)
- `tests/pg_dump/t002_pg_dump.rs`: all target tests enabled with real assertions (no more empty bodies)

## Tests enabled
- `alter_column_set_statistics` — SET STATISTICS 90
- `alter_column_set_storage_col2` — SET STORAGE EXTERNAL
- `alter_column_set_storage_col3` — SET STORAGE MAIN
- `alter_column_set_n_distinct` — SET (n_distinct = 5)
- `alter_table_cluster` — CLUSTER ON
- `run_no_large_objects` — pg_dump --no-large-objects suppresses LOs
- `run_no_policies` — pg_dump --no-policies suppresses CREATE POLICY
- `run_schema_plus_large_objects` — pg_dump --schema=public --large-objects forces LOs in

## How to verify
```bash
cd /tmp/pg_plumbing-issue52
PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres cargo test
# Result: 191 passed; 0 failed; 120 ignored
```

## CI
CI must be green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)