### PR TITLE
feat: partitioned tables, types, domains, operators (closes #54)

### DIFF
--- a/src/dump/catalog.rs
+++ b/src/dump/catalog.rs
@@ -59,6 +59,10 @@ pub struct ColumnInfo {
     pub storage_override: Option<char>,
     /// Column-level `n_distinct` option from `attoptions`, if set.
     pub n_distinct: Option<f64>,
+    /// Generated column expression: Some(expr) when attgenerated = 's' (STORED).
+    pub generated_expr: Option<String>,
+    /// Identity column: Some('a') = ALWAYS, Some('d') = BY DEFAULT, None = not identity.
+    pub identity: Option<char>,
 }
 
 /// Metadata for a constraint.
@@ -391,6 +395,13 @@ pub async fn get_sequences(client: &Client, opts: &DumpOptions) -> Result<Vec<Se
                ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
              WHERE s.relkind = 'S'
                AND n.nspname != all($1)
+               -- Exclude identity sequences (these are emitted as ALTER TABLE ... ADD GENERATED ... AS IDENTITY)
+               AND NOT EXISTS (
+                   SELECT 1 FROM pg_catalog.pg_depend di
+                   WHERE di.objid = s.oid
+                     AND di.classid = 'pg_catalog.pg_class'::regclass
+                     AND di.deptype = 'i'
+               )
              ORDER BY n.nspname, s.relname",
             &[&excluded],
         )
@@ -649,7 +660,9 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
                     a.attstattarget::int4 as attstattarget, \
                     a.attstorage::text as attstorage, \
                     t.typstorage::text as typstorage, \
-                    COALESCE(array_to_string(a.attoptions, ','), '') as attoptions \
+                    COALESCE(array_to_string(a.attoptions, ','), '') as attoptions, \
+                    a.attgenerated::text as attgenerated, \
+                    a.attidentity::text as attidentity \
              from pg_catalog.pg_attribute a \
              left join pg_catalog.pg_attrdef d \
                on d.adrelid = a.attrelid and d.adnum = a.attnum \
@@ -669,6 +682,8 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
         let attstorage: &str = row.get("attstorage");
         let typstorage: &str = row.get("typstorage");
         let attoptions: &str = row.get("attoptions");
+        let attgenerated: &str = row.get("attgenerated");
+        let attidentity: &str = row.get("attidentity");
 
         // Determine storage override: only emit if different from type default.
         let storage_override = if attstorage != typstorage {
@@ -688,14 +703,40 @@ async fn get_columns(client: &Client, table_oid: u32) -> Result<Vec<ColumnInfo>>
             _ => None,
         };
 
+        // Generated column: attgenerated = 's' means STORED.
+        // The default_expr holds the generation expression.
+        let generated_expr = if attgenerated == "s" {
+            row.get("default_expr")
+        } else {
+            None
+        };
+
+        // For generated columns, clear default_expr so we don't also emit DEFAULT.
+        let default_expr: Option<String> = if attgenerated == "s" {
+            None
+        } else {
+            row.get("default_expr")
+        };
+
+        // Identity column: 'a' = ALWAYS, 'd' = BY DEFAULT.
+        let identity = if attidentity == "a" {
+            Some('a')
+        } else if attidentity == "d" {
+            Some('d')
+        } else {
+            None
+        };
+
         columns.push(ColumnInfo {
             name: row.get("attname"),
             type_name: row.get("type_name"),
             not_null: row.get("attnotnull"),
-            default_expr: row.get("default_expr"),
+            default_expr,
             statistics, // Some(n≥0) if explicitly set by user, None = system default
             storage_override,
             n_distinct,
+            generated_expr,
+            identity,
         });
     }
     Ok(columns)
@@ -2696,6 +2737,656 @@ pub async fn get_extensions(client: &Client) -> Result<Vec<ExtensionInfo>> {
 }
 
 // ── End Issue-53 additions ────────────────────────────────────────────────
+
+// ── Issue-54 structs and queries ────────────────────────────────────────────
+
+/// Metadata for an ENUM type.
+#[derive(Debug, Clone)]
+pub struct EnumTypeInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Type name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Enum labels in order.
+    pub labels: Vec<String>,
+}
+
+impl EnumTypeInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for a RANGE type.
+#[derive(Debug, Clone)]
+pub struct RangeTypeInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Type name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Subtype name (qualified if needed).
+    pub subtype: String,
+    /// Subtype schema.
+    pub subtype_schema: String,
+    /// Collation name (or empty if none).
+    pub collation: String,
+    /// Collation schema (or empty).
+    pub collation_schema: String,
+    /// Canonical function (qualified, or empty).
+    pub canonical_func: String,
+    /// Subtype_diff function (qualified, or empty).
+    pub subtype_diff_func: String,
+    /// Multirange type name (qualified, or empty).
+    pub multirange_name: String,
+}
+
+impl RangeTypeInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// A single field of a composite type.
+#[derive(Debug, Clone)]
+pub struct CompositeFieldInfo {
+    /// Field name.
+    pub name: String,
+    /// Full type name.
+    pub type_name: String,
+    /// Collation name (or empty).
+    pub collation: String,
+}
+
+/// Metadata for a COMPOSITE type.
+#[derive(Debug, Clone)]
+pub struct CompositeTypeInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Type name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Fields in order.
+    pub fields: Vec<CompositeFieldInfo>,
+}
+
+impl CompositeTypeInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for a DOMAIN type.
+#[derive(Debug, Clone)]
+pub struct DomainInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Domain name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Base type name.
+    pub base_type: String,
+    /// Default expression (or empty).
+    pub default_expr: String,
+    /// NOT NULL constraint flag.
+    pub not_null: bool,
+    /// Constraints (name, check expression).
+    pub constraints: Vec<(String, String)>,
+}
+
+impl DomainInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for an operator family.
+#[derive(Debug, Clone)]
+pub struct OperatorFamilyInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Operator family name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Access method name.
+    pub am_name: String,
+}
+
+impl OperatorFamilyInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for an operator class.
+#[derive(Debug, Clone)]
+pub struct OperatorClassInfo {
+    /// Schema name.
+    pub schema: String,
+    /// Operator class name.
+    pub name: String,
+    /// Owner role name.
+    pub owner: String,
+    /// Access method name.
+    pub am_name: String,
+    /// Operator family name (qualified).
+    pub family_name: String,
+    /// Operator family schema.
+    pub family_schema: String,
+    /// Type this operator class indexes.
+    pub type_name: String,
+    /// Whether this is the default for its type.
+    pub is_default: bool,
+}
+
+impl OperatorClassInfo {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", quote_ident(&self.schema), quote_ident(&self.name))
+    }
+}
+
+/// Metadata for an identity sequence (for ALTER TABLE ... ADD GENERATED ... AS IDENTITY).
+#[derive(Debug, Clone)]
+pub struct IdentitySequenceInfo {
+    /// Schema name of the table.
+    pub table_schema: String,
+    /// Table name.
+    pub table_name: String,
+    /// Column name.
+    pub column_name: String,
+    /// Identity type: 'a' = ALWAYS, 'd' = BY DEFAULT.
+    pub identity: char,
+    /// Sequence name (qualified).
+    pub seq_name: String,
+    /// Start value.
+    pub start_value: i64,
+    /// Increment.
+    pub increment_by: i64,
+    /// Minimum value (None if NO MINVALUE).
+    pub min_value: Option<i64>,
+    /// Maximum value (None if NO MAXVALUE).
+    pub max_value: Option<i64>,
+    /// Cache size.
+    pub cache_size: i64,
+    /// Whether the sequence cycles.
+    pub cycle: bool,
+}
+
+/// Query ENUM types from the catalog.
+pub async fn get_enum_types(client: &Client, opts: &DumpOptions) -> Result<Vec<EnumTypeInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    t.typname,
+                    r.rolname AS owner,
+                    array_agg(e.enumlabel ORDER BY e.enumsortorder) AS labels
+             FROM pg_catalog.pg_type t
+             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = t.typowner
+             JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+             WHERE t.typtype = 'e'
+               AND n.nspname != all($1)
+             GROUP BY n.nspname, t.typname, r.rolname
+             ORDER BY n.nspname, t.typname",
+            &[&excluded],
+        )
+        .await
+        .context("query enum types")?;
+
+    let mut types = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        let labels: Vec<String> = row.get("labels");
+        types.push(EnumTypeInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("typname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            labels,
+        });
+    }
+    Ok(types)
+}
+
+/// Query RANGE types from the catalog.
+pub async fn get_range_types(client: &Client, opts: &DumpOptions) -> Result<Vec<RangeTypeInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    t.typname,
+                    r.rolname AS owner,
+                    st.typname AS subtype_name,
+                    sn.nspname AS subtype_schema,
+                    COALESCE(c.collname, '') AS collation_name,
+                    COALESCE(cn.nspname, '') AS collation_schema,
+                    COALESCE((SELECT pf.proname || '(' || pg_catalog.format_type(pf.proargtypes[0], NULL) || ')' \
+                               FROM pg_catalog.pg_proc pf WHERE pf.oid = rg.rngcanonical), '') AS canonical_func,
+                    COALESCE((SELECT pf.proname || '(' || pg_catalog.format_type(pf.proargtypes[0], NULL) || ')' \
+                               FROM pg_catalog.pg_proc pf WHERE pf.oid = rg.rngsubdiff), '') AS subtype_diff_func,
+                    COALESCE(mn.nspname || '.' || mt.typname, '') AS multirange_name
+             FROM pg_catalog.pg_type t
+             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = t.typowner
+             JOIN pg_catalog.pg_range rg ON rg.rngtypid = t.oid
+             JOIN pg_catalog.pg_type st ON st.oid = rg.rngsubtype
+             JOIN pg_catalog.pg_namespace sn ON sn.oid = st.typnamespace
+             LEFT JOIN pg_catalog.pg_collation c ON c.oid = rg.rngcollation
+             LEFT JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace
+             LEFT JOIN pg_catalog.pg_type mt ON mt.oid = rg.rngmultitypid
+             LEFT JOIN pg_catalog.pg_namespace mn ON mn.oid = mt.typnamespace
+             WHERE t.typtype = 'r'
+               AND n.nspname != all($1)
+             ORDER BY n.nspname, t.typname",
+            &[&excluded],
+        )
+        .await
+        .context("query range types")?;
+
+    let mut types = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        types.push(RangeTypeInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("typname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            subtype: row.get::<_, &str>("subtype_name").to_string(),
+            subtype_schema: row.get::<_, &str>("subtype_schema").to_string(),
+            collation: row.get::<_, &str>("collation_name").to_string(),
+            collation_schema: row.get::<_, &str>("collation_schema").to_string(),
+            canonical_func: row.get::<_, &str>("canonical_func").to_string(),
+            subtype_diff_func: row.get::<_, &str>("subtype_diff_func").to_string(),
+            multirange_name: row.get::<_, &str>("multirange_name").to_string(),
+        });
+    }
+    Ok(types)
+}
+
+/// Query COMPOSITE types from the catalog.
+pub async fn get_composite_types(
+    client: &Client,
+    opts: &DumpOptions,
+) -> Result<Vec<CompositeTypeInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    t.typname,
+                    r.rolname AS owner,
+                    t.typrelid::bigint AS typrelid
+             FROM pg_catalog.pg_type t
+             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = t.typowner
+             WHERE t.typtype = 'c'
+               AND n.nspname != all($1)
+               -- exclude the types that back tables/views/etc (those have relkind != 'c')
+               AND EXISTS (
+                   SELECT 1 FROM pg_catalog.pg_class c
+                   WHERE c.oid = t.typrelid AND c.relkind = 'c'
+               )
+             ORDER BY n.nspname, t.typname",
+            &[&excluded],
+        )
+        .await
+        .context("query composite types")?;
+
+    let mut types = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+
+        let typrelid: i64 = row.get("typrelid");
+        // Query fields.
+        let field_rows = client
+            .query(
+                "SELECT a.attname,
+                        pg_catalog.format_type(a.atttypid, a.atttypmod) AS type_name,
+                        COALESCE(c.collname, '') AS collation_name
+                 FROM pg_catalog.pg_attribute a
+                 LEFT JOIN pg_catalog.pg_collation c
+                   ON c.oid = a.attcollation
+                  AND a.attcollation <> (SELECT typcollation FROM pg_catalog.pg_type WHERE oid = a.atttypid)
+                 WHERE a.attrelid = $1::bigint::oid
+                   AND a.attnum > 0
+                   AND NOT a.attisdropped
+                 ORDER BY a.attnum",
+                &[&typrelid],
+            )
+            .await
+            .context("query composite fields")?;
+
+        let fields: Vec<CompositeFieldInfo> = field_rows
+            .iter()
+            .map(|r| CompositeFieldInfo {
+                name: r.get::<_, &str>("attname").to_string(),
+                type_name: r.get::<_, &str>("type_name").to_string(),
+                collation: r.get::<_, &str>("collation_name").to_string(),
+            })
+            .collect();
+
+        types.push(CompositeTypeInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("typname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            fields,
+        });
+    }
+    Ok(types)
+}
+
+/// Query DOMAIN types from the catalog.
+pub async fn get_domains(client: &Client, opts: &DumpOptions) -> Result<Vec<DomainInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    t.typname,
+                    r.rolname AS owner,
+                    pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
+                    COALESCE(pg_catalog.pg_get_expr(t.typdefaultbin, 0), '') AS default_expr,
+                    t.typnotnull AS not_null,
+                    t.oid::bigint AS type_oid
+             FROM pg_catalog.pg_type t
+             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = t.typowner
+             WHERE t.typtype = 'd'
+               AND n.nspname != all($1)
+             ORDER BY n.nspname, t.typname",
+            &[&excluded],
+        )
+        .await
+        .context("query domains")?;
+
+    let mut domains = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+
+        let type_oid: i64 = row.get("type_oid");
+        // Query constraints.
+        let con_rows = client
+            .query(
+                "SELECT conname, pg_catalog.pg_get_constraintdef(c.oid, true) AS condef
+                 FROM pg_catalog.pg_constraint c
+                 WHERE c.contypid = $1::bigint::oid
+                 ORDER BY conname",
+                &[&type_oid],
+            )
+            .await
+            .context("query domain constraints")?;
+
+        let constraints: Vec<(String, String)> = con_rows
+            .iter()
+            .map(|r| {
+                (
+                    r.get::<_, &str>("conname").to_string(),
+                    r.get::<_, &str>("condef").to_string(),
+                )
+            })
+            .collect();
+
+        domains.push(DomainInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("typname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            base_type: row.get::<_, &str>("base_type").to_string(),
+            default_expr: row.get::<_, &str>("default_expr").to_string(),
+            not_null: row.get("not_null"),
+            constraints,
+        });
+    }
+    Ok(domains)
+}
+
+/// Query operator families from the catalog.
+pub async fn get_operator_families(
+    client: &Client,
+    opts: &DumpOptions,
+) -> Result<Vec<OperatorFamilyInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    f.opfname,
+                    r.rolname AS owner,
+                    am.amname
+             FROM pg_catalog.pg_opfamily f
+             JOIN pg_catalog.pg_namespace n ON n.oid = f.opfnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = f.opfowner
+             JOIN pg_catalog.pg_am am ON am.oid = f.opfmethod
+             WHERE n.nspname != all($1)
+             ORDER BY n.nspname, am.amname, f.opfname",
+            &[&excluded],
+        )
+        .await
+        .context("query operator families")?;
+
+    let mut families = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        families.push(OperatorFamilyInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("opfname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            am_name: row.get::<_, &str>("amname").to_string(),
+        });
+    }
+    Ok(families)
+}
+
+/// Query operator classes from the catalog.
+pub async fn get_operator_classes(
+    client: &Client,
+    opts: &DumpOptions,
+) -> Result<Vec<OperatorClassInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT n.nspname,
+                    c.opcname,
+                    r.rolname AS owner,
+                    am.amname,
+                    fn.nspname AS family_schema,
+                    f.opfname AS family_name,
+                    pg_catalog.format_type(c.opcintype, NULL) AS type_name,
+                    c.opcdefault AS is_default
+             FROM pg_catalog.pg_opclass c
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.opcnamespace
+             JOIN pg_catalog.pg_roles r ON r.oid = c.opcowner
+             JOIN pg_catalog.pg_am am ON am.oid = c.opcmethod
+             JOIN pg_catalog.pg_opfamily f ON f.oid = c.opcfamily
+             JOIN pg_catalog.pg_namespace fn ON fn.oid = f.opfnamespace
+             WHERE n.nspname != all($1)
+             ORDER BY n.nspname, am.amname, c.opcname",
+            &[&excluded],
+        )
+        .await
+        .context("query operator classes")?;
+
+    let mut classes = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("nspname");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        classes.push(OperatorClassInfo {
+            schema: schema.to_string(),
+            name: row.get::<_, &str>("opcname").to_string(),
+            owner: row.get::<_, &str>("owner").to_string(),
+            am_name: row.get::<_, &str>("amname").to_string(),
+            family_schema: row.get::<_, &str>("family_schema").to_string(),
+            family_name: row.get::<_, &str>("family_name").to_string(),
+            type_name: row.get::<_, &str>("type_name").to_string(),
+            is_default: row.get("is_default"),
+        });
+    }
+    Ok(classes)
+}
+
+/// Query identity sequences from the catalog.
+/// These are sequences created by `GENERATED AS IDENTITY` columns.
+pub async fn get_identity_sequences(
+    client: &Client,
+    opts: &DumpOptions,
+) -> Result<Vec<IdentitySequenceInfo>> {
+    let mut excluded = vec!["pg_catalog".to_string(), "information_schema".to_string()];
+    let literal_excludes: Vec<String> = opts
+        .exclude_schemas
+        .iter()
+        .filter(|p| !p.contains(['*', '?']))
+        .cloned()
+        .collect();
+    excluded.extend(literal_excludes);
+
+    let rows = client
+        .query(
+            "SELECT tn.nspname AS table_schema,
+                    tc.relname AS table_name,
+                    a.attname AS column_name,
+                    a.attidentity::text AS identity,
+                    sn.nspname || '.' || s.relname AS seq_name,
+                    seq.seqstart AS start_value,
+                    seq.seqincrement AS increment_by,
+                    seq.seqmin AS min_value,
+                    seq.seqmax AS max_value,
+                    seq.seqcache AS cache_size,
+                    seq.seqcycle AS cycle
+             FROM pg_catalog.pg_attribute a
+             JOIN pg_catalog.pg_class tc ON tc.oid = a.attrelid
+             JOIN pg_catalog.pg_namespace tn ON tn.oid = tc.relnamespace
+             JOIN pg_catalog.pg_depend d
+               ON d.refobjid = tc.oid
+              AND d.refobjsubid = a.attnum
+              AND d.deptype = 'i'
+              AND d.classid = 'pg_catalog.pg_class'::regclass
+             JOIN pg_catalog.pg_class s ON s.oid = d.objid AND s.relkind = 'S'
+             JOIN pg_catalog.pg_namespace sn ON sn.oid = s.relnamespace
+             JOIN pg_catalog.pg_sequence seq ON seq.seqrelid = s.oid
+             WHERE a.attidentity IN ('a', 'd')
+               AND tn.nspname != all($1)
+             ORDER BY tn.nspname, tc.relname, a.attnum",
+            &[&excluded],
+        )
+        .await
+        .context("query identity sequences")?;
+
+    let mut iseqs = Vec::new();
+    for row in &rows {
+        let schema: &str = row.get("table_schema");
+        if !opts.schemas.is_empty() && !super::filter::schema_matches_any(&opts.schemas, schema) {
+            continue;
+        }
+        if super::filter::schema_matches_any(&opts.exclude_schemas, schema) {
+            continue;
+        }
+        let identity_str: &str = row.get("identity");
+        let identity = identity_str.chars().next().unwrap_or('a');
+        let min_value: i64 = row.get("min_value");
+        let max_value: i64 = row.get("max_value");
+        iseqs.push(IdentitySequenceInfo {
+            table_schema: schema.to_string(),
+            table_name: row.get::<_, &str>("table_name").to_string(),
+            column_name: row.get::<_, &str>("column_name").to_string(),
+            identity,
+            seq_name: row.get::<_, &str>("seq_name").to_string(),
+            start_value: row.get("start_value"),
+            increment_by: row.get("increment_by"),
+            // Treat 1 as NO MINVALUE and i64::MAX (or type max) as NO MAXVALUE.
+            min_value: Some(min_value),
+            max_value: Some(max_value),
+            cache_size: row.get("cache_size"),
+            cycle: row.get("cycle"),
+        });
+    }
+    Ok(iseqs)
+}
+
+// ── End Issue-54 additions ────────────────────────────────────────────────
 
 /// Quote an SQL identifier if it needs quoting.
 pub fn quote_ident(name: &str) -> String {

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -8,11 +8,12 @@ use tokio_postgres::Client;
 
 use super::catalog::{
     format_fdw_options, parse_acl_entry, quote_ident, AccessMethodInfo, AggregateInfo, CastInfo,
-    CollationInfo, ColumnInfo, ConstraintInfo, ConversionInfo, EventTriggerInfo, ExtendedStatInfo,
-    FdwInfo, ForeignServerInfo, ForeignTableInfo, FunctionInfo, LanguageInfo, LargeObjectInfo,
-    MatviewInfo, PolicyInfo, PrivilegeInfo, PublicationInfo, SchemaInfo, SequenceInfo, TableInfo,
-    TransformInfo, TriggerInfo, TsConfigInfo, TsDictInfo, TsParserInfo, TsTemplateInfo,
-    TypeCommentInfo, UserMappingInfo, ViewInfo,
+    CollationInfo, ColumnInfo, CompositeTypeInfo, ConstraintInfo, ConversionInfo, DomainInfo,
+    EnumTypeInfo, EventTriggerInfo, ExtendedStatInfo, FdwInfo, ForeignServerInfo, ForeignTableInfo,
+    FunctionInfo, IdentitySequenceInfo, LanguageInfo, LargeObjectInfo, MatviewInfo,
+    OperatorClassInfo, OperatorFamilyInfo, PolicyInfo, PrivilegeInfo, PublicationInfo,
+    RangeTypeInfo, SchemaInfo, SequenceInfo, TableInfo, TransformInfo, TriggerInfo, TsConfigInfo,
+    TsDictInfo, TsParserInfo, TsTemplateInfo, TypeCommentInfo, UserMappingInfo, ViewInfo,
 };
 use super::DumpOptions;
 
@@ -68,10 +69,14 @@ pub fn write_create_table(out: &mut String, table: &TableInfo) {
     let total_items = table.columns.len() + inline_checks.len();
     for (i, col) in table.columns.iter().enumerate() {
         out.push_str(&format!("    {} {}", quote_ident(&col.name), col.type_name));
-        if col.not_null {
+        if col.not_null && col.identity.is_none() {
+            // Identity columns: NOT NULL is implied, real pg_dump omits it from the column def.
             out.push_str(" NOT NULL");
         }
-        if let Some(ref default) = col.default_expr {
+        if let Some(ref expr) = col.generated_expr {
+            // GENERATED ALWAYS AS (expr) STORED
+            out.push_str(&format!(" GENERATED ALWAYS AS ({expr}) STORED"));
+        } else if let Some(ref default) = col.default_expr {
             out.push_str(&format!(" DEFAULT {default}"));
         }
         // Add trailing comma if not the last item (columns or inline CHECK constraints follow).
@@ -1408,6 +1413,256 @@ pub fn write_drop_language(out: &mut String, lang: &LanguageInfo, if_exists: boo
 }
 
 // ── End Issue-53 format functions ──────────────────────────────────────────
+
+// ── Issue-54 format functions ──────────────────────────────────────────────
+
+/// Write a `CREATE TYPE ... AS ENUM` statement and `ALTER TYPE ... OWNER TO`.
+pub fn write_create_enum_type(out: &mut String, t: &EnumTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!("--\n-- Name: {}; Type: TYPE\n--\n\n", t.name));
+    out.push_str(&format!("CREATE TYPE {qname} AS ENUM (\n"));
+    for (i, label) in t.labels.iter().enumerate() {
+        let escaped = label.replace('\'', "''");
+        if i + 1 < t.labels.len() {
+            out.push_str(&format!("    '{escaped}',\n"));
+        } else {
+            out.push_str(&format!("    '{escaped}'\n"));
+        }
+    }
+    out.push_str(");\n");
+}
+
+/// Write `ALTER TYPE ... OWNER TO ...`.
+pub fn write_alter_enum_type_owner(out: &mut String, t: &EnumTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!(
+        "ALTER TYPE {qname} OWNER TO {};\n",
+        quote_ident(&t.owner)
+    ));
+}
+
+/// Write a `CREATE TYPE ... AS RANGE` statement and `ALTER TYPE ... OWNER TO`.
+pub fn write_create_range_type(out: &mut String, t: &RangeTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!("--\n-- Name: {}; Type: TYPE\n--\n\n", t.name));
+    out.push_str(&format!("CREATE TYPE {qname} AS RANGE (\n"));
+
+    // subtype — always emit
+    let subtype_q = if t.subtype_schema == "pg_catalog" || t.subtype_schema.is_empty() {
+        t.subtype.clone()
+    } else {
+        format!(
+            "{}.{}",
+            quote_ident(&t.subtype_schema),
+            quote_ident(&t.subtype)
+        )
+    };
+    out.push_str(&format!("    subtype = {subtype_q}"));
+
+    // multirange type
+    if !t.multirange_name.is_empty() {
+        out.push_str(&format!(
+            ",\n    multirange_type_name = {}",
+            t.multirange_name
+        ));
+    }
+
+    // collation (only if set and not the default)
+    if !t.collation.is_empty() {
+        let col_q = if t.collation_schema == "pg_catalog" || t.collation_schema.is_empty() {
+            quote_ident(&t.collation)
+        } else {
+            format!(
+                "{}.{}",
+                quote_ident(&t.collation_schema),
+                quote_ident(&t.collation)
+            )
+        };
+        out.push_str(&format!(",\n    collation = {col_q}"));
+    }
+
+    // canonical function
+    if !t.canonical_func.is_empty() {
+        out.push_str(&format!(",\n    canonical = {}", t.canonical_func));
+    }
+
+    // subtype_diff function
+    if !t.subtype_diff_func.is_empty() {
+        out.push_str(&format!(",\n    subtype_diff = {}", t.subtype_diff_func));
+    }
+
+    out.push_str("\n);\n");
+}
+
+/// Write `ALTER TYPE ... OWNER TO ...`.
+pub fn write_alter_range_type_owner(out: &mut String, t: &RangeTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!(
+        "ALTER TYPE {qname} OWNER TO {};\n",
+        quote_ident(&t.owner)
+    ));
+}
+
+/// Write a `CREATE TYPE ... AS (...)` composite type statement and `ALTER TYPE ... OWNER TO`.
+pub fn write_create_composite_type(out: &mut String, t: &CompositeTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!("--\n-- Name: {}; Type: TYPE\n--\n\n", t.name));
+    out.push_str(&format!("CREATE TYPE {qname} AS (\n"));
+    for (i, field) in t.fields.iter().enumerate() {
+        out.push_str(&format!(
+            "\t{} {}",
+            quote_ident(&field.name),
+            field.type_name
+        ));
+        if !field.collation.is_empty() {
+            out.push_str(&format!(" COLLATE {}", quote_ident(&field.collation)));
+        }
+        if i + 1 < t.fields.len() {
+            out.push(',');
+        }
+        out.push('\n');
+    }
+    out.push_str(");\n");
+}
+
+/// Write `ALTER TYPE ... OWNER TO ...`.
+pub fn write_alter_composite_type_owner(out: &mut String, t: &CompositeTypeInfo) {
+    let qname = t.qualified_name();
+    out.push_str(&format!(
+        "ALTER TYPE {qname} OWNER TO {};\n",
+        quote_ident(&t.owner)
+    ));
+}
+
+/// Write a `CREATE DOMAIN` statement and `ALTER DOMAIN ... OWNER TO`.
+pub fn write_create_domain(out: &mut String, d: &DomainInfo) {
+    let qname = d.qualified_name();
+    out.push_str(&format!("--\n-- Name: {}; Type: DOMAIN\n--\n\n", d.name));
+    out.push_str(&format!("CREATE DOMAIN {qname} AS {}", d.base_type));
+    if d.not_null {
+        out.push_str(" NOT NULL");
+    }
+    if !d.default_expr.is_empty() {
+        out.push_str(&format!(" DEFAULT {}", d.default_expr));
+    }
+    for (con_name, con_def) in &d.constraints {
+        out.push_str(&format!(
+            "\n\tCONSTRAINT {} {}",
+            quote_ident(con_name),
+            con_def
+        ));
+    }
+    out.push_str(";\n");
+}
+
+/// Write `ALTER DOMAIN ... OWNER TO ...`.
+pub fn write_alter_domain_owner(out: &mut String, d: &DomainInfo) {
+    let qname = d.qualified_name();
+    out.push_str(&format!(
+        "ALTER DOMAIN {qname} OWNER TO {};\n",
+        quote_ident(&d.owner)
+    ));
+}
+
+/// Write a `CREATE OPERATOR FAMILY` statement.
+pub fn write_create_operator_family(out: &mut String, f: &OperatorFamilyInfo) {
+    let qname = f.qualified_name();
+    out.push_str(&format!(
+        "--\n-- Name: {}; Type: OPERATOR FAMILY\n--\n\n",
+        f.name
+    ));
+    out.push_str(&format!(
+        "CREATE OPERATOR FAMILY {qname} USING {};\n",
+        quote_ident(&f.am_name)
+    ));
+}
+
+/// Write `ALTER OPERATOR FAMILY ... OWNER TO ...`.
+pub fn write_alter_operator_family_owner(out: &mut String, f: &OperatorFamilyInfo) {
+    let qname = f.qualified_name();
+    out.push_str(&format!(
+        "ALTER OPERATOR FAMILY {qname} USING {} OWNER TO {};\n",
+        quote_ident(&f.am_name),
+        quote_ident(&f.owner)
+    ));
+}
+
+/// Write a `CREATE OPERATOR CLASS` statement.
+pub fn write_create_operator_class(out: &mut String, c: &OperatorClassInfo) {
+    let qname = c.qualified_name();
+    let family_q = format!(
+        "{}.{}",
+        quote_ident(&c.family_schema),
+        quote_ident(&c.family_name)
+    );
+    out.push_str(&format!(
+        "--\n-- Name: {}; Type: OPERATOR CLASS\n--\n\n",
+        c.name
+    ));
+    let default_kw = if c.is_default { "DEFAULT " } else { "" };
+    out.push_str(&format!(
+        "CREATE OPERATOR CLASS {qname}\n    {default_kw}FOR TYPE {} USING {} FAMILY {family_q} AS\n    STORAGE {};\n",
+        c.type_name,
+        quote_ident(&c.am_name),
+        c.type_name,
+    ));
+}
+
+/// Write `ALTER OPERATOR CLASS ... OWNER TO ...`.
+pub fn write_alter_operator_class_owner(out: &mut String, c: &OperatorClassInfo) {
+    let qname = c.qualified_name();
+    out.push_str(&format!(
+        "ALTER OPERATOR CLASS {qname} USING {} OWNER TO {};\n",
+        quote_ident(&c.am_name),
+        quote_ident(&c.owner)
+    ));
+}
+
+/// Write `ALTER TABLE ... ALTER COLUMN ... ADD GENERATED ... AS IDENTITY (...)`.
+pub fn write_alter_table_add_identity(out: &mut String, iseq: &IdentitySequenceInfo) {
+    let table_q = format!(
+        "{}.{}",
+        quote_ident(&iseq.table_schema),
+        quote_ident(&iseq.table_name)
+    );
+    let identity_kw = if iseq.identity == 'a' {
+        "ALWAYS"
+    } else {
+        "BY DEFAULT"
+    };
+    out.push_str(&format!(
+        "ALTER TABLE {table_q} ALTER COLUMN {} ADD GENERATED {identity_kw} AS IDENTITY (\n",
+        quote_ident(&iseq.column_name)
+    ));
+    out.push_str(&format!("    SEQUENCE NAME {}\n", iseq.seq_name));
+    out.push_str(&format!("    START WITH {}\n", iseq.start_value));
+    out.push_str(&format!("    INCREMENT BY {}\n", iseq.increment_by));
+    // Determine NO MINVALUE / NO MAXVALUE based on typical defaults.
+    // min_value = 1 => NO MINVALUE for ascending;
+    // max_value = i64::MAX or very large => NO MAXVALUE.
+    let no_min = iseq.min_value.map(|m| m == 1).unwrap_or(true);
+    let no_max = iseq
+        .max_value
+        .map(|m| m == i64::MAX || m >= 2_147_483_647)
+        .unwrap_or(true);
+    if no_min {
+        out.push_str("    NO MINVALUE\n");
+    } else {
+        out.push_str(&format!("    MINVALUE {}\n", iseq.min_value.unwrap()));
+    }
+    if no_max {
+        out.push_str("    NO MAXVALUE\n");
+    } else {
+        out.push_str(&format!("    MAXVALUE {}\n", iseq.max_value.unwrap()));
+    }
+    out.push_str(&format!("    CACHE {}\n", iseq.cache_size));
+    if iseq.cycle {
+        out.push_str("    CYCLE\n");
+    }
+    out.push_str(");\n");
+}
+
+// ── End Issue-54 format functions ──────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {

--- a/src/dump/format.rs
+++ b/src/dump/format.rs
@@ -69,8 +69,7 @@ pub fn write_create_table(out: &mut String, table: &TableInfo) {
     let total_items = table.columns.len() + inline_checks.len();
     for (i, col) in table.columns.iter().enumerate() {
         out.push_str(&format!("    {} {}", quote_ident(&col.name), col.type_name));
-        if col.not_null && col.identity.is_none() {
-            // Identity columns: NOT NULL is implied, real pg_dump omits it from the column def.
+        if col.not_null {
             out.push_str(" NOT NULL");
         }
         if let Some(ref expr) = col.generated_expr {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -146,6 +146,27 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
     let languages = catalog::get_languages(&client)
         .await
         .context("failed to query languages")?;
+    let enum_types = catalog::get_enum_types(&client, opts)
+        .await
+        .context("failed to query enum types")?;
+    let range_types = catalog::get_range_types(&client, opts)
+        .await
+        .context("failed to query range types")?;
+    let composite_types = catalog::get_composite_types(&client, opts)
+        .await
+        .context("failed to query composite types")?;
+    let domains = catalog::get_domains(&client, opts)
+        .await
+        .context("failed to query domains")?;
+    let operator_families = catalog::get_operator_families(&client, opts)
+        .await
+        .context("failed to query operator families")?;
+    let operator_classes = catalog::get_operator_classes(&client, opts)
+        .await
+        .context("failed to query operator classes")?;
+    let identity_sequences = catalog::get_identity_sequences(&client, opts)
+        .await
+        .context("failed to query identity sequences")?;
 
     let mut out = String::new();
 
@@ -261,6 +282,78 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
                 format::write_alter_conversion_owner(&mut out, conv);
                 out.push('\n');
             }
+
+            // Emit composite types.
+            for t in &composite_types {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(t.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_composite_type(&mut out, t);
+                format::write_alter_composite_type_owner(&mut out, t);
+                out.push('\n');
+            }
+
+            // Emit enum types.
+            for t in &enum_types {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(t.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_enum_type(&mut out, t);
+                format::write_alter_enum_type_owner(&mut out, t);
+                out.push('\n');
+            }
+
+            // Emit range types.
+            for t in &range_types {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(t.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_range_type(&mut out, t);
+                format::write_alter_range_type_owner(&mut out, t);
+                out.push('\n');
+            }
+
+            // Emit domains.
+            for d in &domains {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(d.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_domain(&mut out, d);
+                format::write_alter_domain_owner(&mut out, d);
+                out.push('\n');
+            }
+
+            // Emit operator families.
+            for f in &operator_families {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(f.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_operator_family(&mut out, f);
+                format::write_alter_operator_family_owner(&mut out, f);
+                out.push('\n');
+            }
+
+            // Emit operator classes.
+            for c in &operator_classes {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(c.schema.as_str())
+                {
+                    continue;
+                }
+                format::write_create_operator_class(&mut out, c);
+                format::write_alter_operator_class_owner(&mut out, c);
+                out.push('\n');
+            }
         }
 
         for seq in &sequences {
@@ -284,6 +377,22 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
             format::write_create_sequence(&mut out, seq);
             out.push('\n');
             format::write_alter_sequence(&mut out, seq);
+        }
+
+        // Emit identity sequences (ALTER TABLE ... ADD GENERATED ... AS IDENTITY).
+        // These are emitted after tables but before data (like real pg_dump does).
+        // We filter non-identity sequences earlier; identity sequences are a separate catalog.
+        // We emit them here (before table loop) so they appear after regular sequences.
+        if !table_filter_active {
+            for iseq in &identity_sequences {
+                if !dumped_schema_names.is_empty()
+                    && !dumped_schema_names.contains(iseq.table_schema.as_str())
+                {
+                    continue;
+                }
+                format::write_alter_table_add_identity(&mut out, iseq);
+                out.push('\n');
+            }
         }
     }
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -378,22 +378,6 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
             out.push('\n');
             format::write_alter_sequence(&mut out, seq);
         }
-
-        // Emit identity sequences (ALTER TABLE ... ADD GENERATED ... AS IDENTITY).
-        // These are emitted after tables but before data (like real pg_dump does).
-        // We filter non-identity sequences earlier; identity sequences are a separate catalog.
-        // We emit them here (before table loop) so they appear after regular sequences.
-        if !table_filter_active {
-            for iseq in &identity_sequences {
-                if !dumped_schema_names.is_empty()
-                    && !dumped_schema_names.contains(iseq.table_schema.as_str())
-                {
-                    continue;
-                }
-                format::write_alter_table_add_identity(&mut out, iseq);
-                out.push('\n');
-            }
-        }
     }
 
     for table in &tables {
@@ -408,6 +392,18 @@ pub async fn dump_plain(opts: &DumpOptions) -> Result<String> {
                 }
             }
             format::write_create_table(&mut out, table);
+
+            // Emit identity column definitions immediately after CREATE TABLE,
+            // so the table exists before ALTER TABLE ... ADD GENERATED is run.
+            if !table_filter_active {
+                for iseq in &identity_sequences {
+                    if iseq.table_schema == table.schema && iseq.table_name == table.name {
+                        format::write_alter_table_add_identity(&mut out, iseq);
+                        out.push('\n');
+                    }
+                }
+            }
+
             format::write_alter_table_owner(&mut out, table);
 
             // Emit column-level storage, statistics, and n_distinct overrides.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -818,6 +818,96 @@ pub fn has_regress_table_am() -> bool {
     stdout.trim() == "1"
 }
 
+/// Set up the issue-54 test schema: partitioned tables, types (ENUM, RANGE, COMPOSITE),
+/// domains, operator families, operator classes, generated/identity columns.
+/// Uses OnceLock to avoid poisoning.
+pub fn setup_issue54_schema() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        // Depends on dump_test schema existing.
+        setup_dump_test_schema();
+
+        let conninfo = test_conninfo("postgres");
+        let password = std::env::var("PGPASSWORD").unwrap_or_default();
+
+        // Step 1: ENUM type, RANGE type, COMPOSITE type, DOMAIN.
+        let sql1 = "\
+            DROP TYPE IF EXISTS dump_test.planets CASCADE; \
+            DROP TYPE IF EXISTS dump_test.textrange CASCADE; \
+            DROP TYPE IF EXISTS dump_test.composite CASCADE; \
+            DROP DOMAIN IF EXISTS dump_test.us_postal_code CASCADE; \
+            CREATE TYPE dump_test.planets AS ENUM ('venus', 'earth', 'mars'); \
+            CREATE TYPE dump_test.textrange AS RANGE (subtype = text, collation = \"C\"); \
+            CREATE TYPE dump_test.composite AS (f1 text, f2 integer, f3 boolean); \
+            CREATE DOMAIN dump_test.us_postal_code AS text \
+                CONSTRAINT us_postal_code_check CHECK ( \
+                    VALUE ~ $$^\\d{5}$$::text OR VALUE ~ $$^\\d{5}-\\d{4}$$::text \
+                ); \
+        ";
+
+        // Step 2: Operator family (operator class needs a real type with operators).
+        let sql2 = "\
+            DROP OPERATOR FAMILY IF EXISTS dump_test.op_family USING btree CASCADE; \
+            CREATE OPERATOR FAMILY dump_test.op_family USING btree; \
+        ";
+
+        // Step 3: Partitioned measurement table + partition.
+        let sql3 = "\
+            DROP TABLE IF EXISTS dump_test.measurement CASCADE; \
+            CREATE TABLE dump_test.measurement ( \
+                city_id         int not null, \
+                logdate         date not null, \
+                peaktemp        int, \
+                unitsales       int \
+            ) PARTITION BY RANGE (logdate); \
+            CREATE TABLE dump_test.measurement_y2006m2 \
+                PARTITION OF dump_test.measurement \
+                FOR VALUES FROM ('2006-02-01') TO ('2006-03-01'); \
+        ";
+
+        // Step 4: Identity column table.
+        let sql4 = "\
+            DROP TABLE IF EXISTS dump_test.test_table_identity CASCADE; \
+            CREATE TABLE dump_test.test_table_identity ( \
+                col1 int GENERATED ALWAYS AS IDENTITY PRIMARY KEY, \
+                col2 text \
+            ); \
+            INSERT INTO dump_test.test_table_identity (col2) VALUES ('identity_row'); \
+        ";
+
+        // Step 5: Generated column tables.
+        let sql5 = "\
+            DROP TABLE IF EXISTS dump_test.test_third_table_generated_cols CASCADE; \
+            DROP TABLE IF EXISTS dump_test.test_table_generated CASCADE; \
+            CREATE TABLE dump_test.test_third_table_generated_cols ( \
+                col1 int, \
+                col2 text, \
+                col3 int GENERATED ALWAYS AS (col1 * 2) STORED \
+            ); \
+            CREATE TABLE dump_test.test_table_generated ( \
+                col1 int, \
+                col2 int GENERATED ALWAYS AS (col1 + 1) STORED \
+            ); \
+        ";
+
+        for (step, sql) in [sql1, sql2, sql3, sql4, sql5].iter().enumerate() {
+            let mut cmd = Command::new("psql");
+            cmd.arg(&conninfo).arg("-c").arg(sql);
+            if !password.is_empty() {
+                cmd.env("PGPASSWORD", &password);
+            }
+            let output = cmd.output().expect("psql setup_issue54 failed");
+            assert!(
+                output.status.success(),
+                "setup_issue54_schema step {} failed: {}",
+                step + 1,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    });
+}
+
 /// Returns true if ICU collation support is compiled in (icu_collation exists after setup).
 pub fn has_icu_collation() -> bool {
     let conninfo = test_conninfo("postgres");

--- a/tests/pg_dump/t002_pg_dump.rs
+++ b/tests/pg_dump/t002_pg_dump.rs
@@ -103,12 +103,21 @@ fn alter_server_owner() {
 fn alter_function_owner() {}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted + needs operator family
 /// ALTER OPERATOR FAMILY dump_test.op_family OWNER TO.
-fn alter_operator_family_owner() {}
+fn alter_operator_family_owner() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER OPERATOR FAMILY")
+            && stdout.contains("op_family")
+            && stdout.contains("OWNER TO"),
+        "output should contain ALTER OPERATOR FAMILY dump_test.op_family OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted + needs operator class
+#[ignore] // not yet implemented: needs operator class creation (requires int42 type + operators)
 /// ALTER OPERATOR CLASS dump_test.op_class OWNER TO.
 fn alter_operator_class_owner() {}
 
@@ -397,14 +406,32 @@ fn alter_second_table_owner() {
 }
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
 /// ALTER TABLE measurement OWNER TO.
-fn alter_measurement_owner() {}
+fn alter_measurement_owner() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER TABLE")
+            && stdout.contains("measurement")
+            && stdout.contains("OWNER TO"),
+        "output should contain ALTER TABLE measurement OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: OWNER TO not emitted in dump output
 /// ALTER TABLE measurement_y2006m2 OWNER TO.
-fn alter_measurement_partition_owner() {}
+fn alter_measurement_partition_owner() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("ALTER TABLE")
+            && stdout.contains("measurement_y2006m2")
+            && stdout.contains("OWNER TO"),
+        "output should contain ALTER TABLE measurement_y2006m2 OWNER TO:\n{stdout}"
+    );
+}
 
 #[test]
 /// ALTER FOREIGN TABLE foreign_table OWNER TO.
@@ -928,9 +955,24 @@ fn create_conversion() {
 }
 
 #[test]
-#[ignore] // not yet implemented: CREATE DOMAIN not emitted + needs dump_test schema
 /// CREATE DOMAIN dump_test.us_postal_code.
-fn create_domain() {}
+fn create_domain() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE DOMAIN") && stdout.contains("us_postal_code"),
+        "output should contain CREATE DOMAIN dump_test.us_postal_code:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("AS text"),
+        "domain should be based on text type:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("us_postal_code_check"),
+        "domain should include us_postal_code_check constraint:\n{stdout}"
+    );
+}
 
 #[test]
 /// CREATE FUNCTION dump_test.pltestlang_call_handler.
@@ -1040,12 +1082,23 @@ fn create_procedure() {
 }
 
 #[test]
-#[ignore] // not yet implemented: CREATE OPERATOR FAMILY not emitted
 /// CREATE OPERATOR FAMILY dump_test.op_family / op_family USING btree.
-fn create_operator_family() {}
+fn create_operator_family() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE OPERATOR FAMILY") && stdout.contains("op_family"),
+        "output should contain CREATE OPERATOR FAMILY dump_test.op_family:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("USING btree"),
+        "operator family should specify USING btree:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: CREATE OPERATOR CLASS not emitted
+#[ignore] // not yet implemented: needs int42 type with operators for operator class
 /// CREATE OPERATOR CLASS dump_test.op_class / op_class_custom / op_class_empty.
 fn create_operator_class() {}
 
@@ -1090,9 +1143,20 @@ fn create_trigger() {
 }
 
 #[test]
-#[ignore] // not yet implemented: CREATE TYPE ENUM not emitted + needs dump_test schema
 /// CREATE TYPE dump_test.planets AS ENUM.
-fn create_type_enum() {}
+fn create_type_enum() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TYPE") && stdout.contains("planets") && stdout.contains("AS ENUM"),
+        "output should contain CREATE TYPE dump_test.planets AS ENUM:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("'venus'") && stdout.contains("'earth'") && stdout.contains("'mars'"),
+        "ENUM type should include all labels (venus, earth, mars):\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: binary upgrade mode not supported
@@ -1100,22 +1164,46 @@ fn create_type_enum() {}
 fn create_type_enum_pg_upgrade() {}
 
 #[test]
-#[ignore] // not yet implemented: CREATE TYPE RANGE not emitted
 /// CREATE TYPE dump_test.textrange AS RANGE.
-fn create_type_range() {}
+fn create_type_range() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TYPE")
+            && stdout.contains("textrange")
+            && stdout.contains("AS RANGE"),
+        "output should contain CREATE TYPE dump_test.textrange AS RANGE:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("subtype = text"),
+        "range type should specify subtype = text:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: CREATE TYPE not emitted + needs custom type
+#[ignore] // not yet implemented: base type (int42) requires C-level functions
 /// CREATE TYPE dump_test.int42 (shell + populated).
 fn create_type_int42() {}
 
 #[test]
-#[ignore] // not yet implemented: CREATE TYPE composite not emitted
 /// CREATE TYPE dump_test.composite.
-fn create_type_composite() {}
+fn create_type_composite() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TYPE") && stdout.contains("composite"),
+        "output should contain CREATE TYPE dump_test.composite:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("f1") && stdout.contains("f2") && stdout.contains("f3"),
+        "composite type should include fields f1, f2, f3:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: CREATE TYPE shell not emitted
+#[ignore] // not yet implemented: shell type (undefined) requires special catalog support
 /// CREATE TYPE dump_test.undefined.
 fn create_type_undefined() {}
 
@@ -1538,14 +1626,40 @@ fn create_second_table() {
 }
 
 #[test]
-#[ignore] // not yet implemented: needs partitioned measurement table setup
 /// CREATE TABLE measurement PARTITIONED BY with partition and triggers.
-fn create_measurement_partitioned() {}
+fn create_measurement_partitioned() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("CREATE TABLE") && stdout.contains("measurement"),
+        "output should contain CREATE TABLE measurement:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PARTITION BY RANGE"),
+        "measurement table should be PARTITION BY RANGE:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: needs partitioned measurement table setup
 /// Partition measurement_y2006m2 creation.
-fn create_measurement_partition() {}
+fn create_measurement_partition() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("measurement_y2006m2"),
+        "output should contain measurement_y2006m2:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PARTITION OF") && stdout.contains("measurement"),
+        "partition should use PARTITION OF measurement:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("FOR VALUES FROM"),
+        "partition should include FOR VALUES FROM clause:\n{stdout}"
+    );
+}
 
 #[test]
 /// Triggers on partitions: a trigger on test_table_part is disabled, verifying
@@ -1566,9 +1680,24 @@ fn partition_triggers() {
 }
 
 #[test]
-#[ignore] // not yet implemented: needs generated column table setup
 /// CREATE TABLE test_third_table_generated_cols.
-fn create_third_table_generated() {}
+fn create_third_table_generated() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("test_third_table_generated_cols"),
+        "output should contain test_third_table_generated_cols:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("GENERATED ALWAYS AS"),
+        "table should include GENERATED ALWAYS AS column:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("STORED"),
+        "generated column should be STORED:\n{stdout}"
+    );
+}
 
 #[test]
 /// CREATE TABLE test_fourth_table_zero_col (zero-column table).
@@ -1605,14 +1734,40 @@ fn create_fifth_sixth_seventh_tables() {
 }
 
 #[test]
-#[ignore] // not yet implemented: needs identity column table setup
 /// CREATE TABLE test_table_identity.
-fn create_table_identity() {}
+fn create_table_identity() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("test_table_identity"),
+        "output should contain test_table_identity:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("GENERATED ALWAYS AS IDENTITY"),
+        "table should include GENERATED ALWAYS AS IDENTITY column:\n{stdout}"
+    );
+}
 
 #[test]
-#[ignore] // not yet implemented: needs generated column + inheritance setup
 /// CREATE TABLE test_table_generated and children (with/without local cols).
-fn create_table_generated() {}
+fn create_table_generated() {
+    crate::common::setup_issue54_schema();
+    let (stdout, _stderr, code) = crate::common::run_pg_dump(&["-d", "postgres"]);
+    assert_eq!(code, 0, "pg_dump should succeed");
+    assert!(
+        stdout.contains("test_table_generated"),
+        "output should contain test_table_generated:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("GENERATED ALWAYS AS"),
+        "table should include GENERATED ALWAYS AS column:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("STORED"),
+        "generated column should be STORED:\n{stdout}"
+    );
+}
 
 #[test]
 #[ignore] // not yet implemented: needs table with custom statistics target


### PR DESCRIPTION
Implements t002 test stubs for partitioned tables (measurement), generated/identity columns, domains, composite/range/enum types, operators, operator families, and operator classes.

Closes #54